### PR TITLE
fix: make LookupFilter synchronously

### DIFF
--- a/framework/Source/Operations/LookupFilter.swift
+++ b/framework/Source/Operations/LookupFilter.swift
@@ -3,7 +3,7 @@ public class LookupFilter: BasicOperation {
     public var lookupImage:PictureInput? { // TODO: Check for retain cycles in all cases here
         didSet {
             lookupImage?.addTarget(self, atTargetIndex:1)
-            lookupImage?.processImage()
+            lookupImage?.processImage(synchronously: true)
         }
     }
     


### PR DESCRIPTION
### Description

Attempting to fix the issue where LookupFilter does not return an image when processing an image with a synchronous call.