### PR TITLE
:sparkles: Implement Grain filter effect

### DIFF
--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -409,6 +409,10 @@
 		BCFCD46720FCE91200560BC9 /* DissolveBlend.metal in Sources */ = {isa = PBXBuildFile; fileRef = BCFCD46620FCE91200560BC9 /* DissolveBlend.metal */; };
 		BCFCD46820FCE91200560BC9 /* DissolveBlend.metal in Sources */ = {isa = PBXBuildFile; fileRef = BCFCD46620FCE91200560BC9 /* DissolveBlend.metal */; };
 		BCFCD46920FCE91800560BC9 /* DissolveBlend.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFCD46420FCE83500560BC9 /* DissolveBlend.swift */; };
+		FB10DA6F2AF8F688000B1AEF /* Grain.metal in Sources */ = {isa = PBXBuildFile; fileRef = FB10DA6D2AF8F688000B1AEF /* Grain.metal */; };
+		FB10DA702AF8F688000B1AEF /* Grain.metal in Sources */ = {isa = PBXBuildFile; fileRef = FB10DA6D2AF8F688000B1AEF /* Grain.metal */; };
+		FB10DA712AF8F688000B1AEF /* Grain.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB10DA6E2AF8F688000B1AEF /* Grain.swift */; };
+		FB10DA722AF8F688000B1AEF /* Grain.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB10DA6E2AF8F688000B1AEF /* Grain.swift */; };
 		FBE32DE42760CA9400DDDE68 /* UnsharpMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE32DE22760CA9400DDDE68 /* UnsharpMask.swift */; };
 		FBE32DE52760CA9400DDDE68 /* UnsharpMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE32DE22760CA9400DDDE68 /* UnsharpMask.swift */; };
 		FBE32DE62760CA9400DDDE68 /* UnsharpMask.metal in Sources */ = {isa = PBXBuildFile; fileRef = FBE32DE32760CA9400DDDE68 /* UnsharpMask.metal */; };
@@ -623,6 +627,8 @@
 		BCE0BE9D20D6E3C80006E120 /* ImageOrientation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageOrientation.swift; path = Source/ImageOrientation.swift; sourceTree = "<group>"; };
 		BCFCD46420FCE83500560BC9 /* DissolveBlend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DissolveBlend.swift; path = Source/Operations/DissolveBlend.swift; sourceTree = "<group>"; };
 		BCFCD46620FCE91200560BC9 /* DissolveBlend.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; name = DissolveBlend.metal; path = Source/Operations/DissolveBlend.metal; sourceTree = "<group>"; };
+		FB10DA6D2AF8F688000B1AEF /* Grain.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; name = Grain.metal; path = Source/Operations/Grain.metal; sourceTree = "<group>"; };
+		FB10DA6E2AF8F688000B1AEF /* Grain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Grain.swift; path = Source/Operations/Grain.swift; sourceTree = "<group>"; };
 		FBE32DE22760CA9400DDDE68 /* UnsharpMask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnsharpMask.swift; path = Source/Operations/UnsharpMask.swift; sourceTree = "<group>"; };
 		FBE32DE32760CA9400DDDE68 /* UnsharpMask.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; name = UnsharpMask.metal; path = Source/Operations/UnsharpMask.metal; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -701,6 +707,8 @@
 				79DD50CC213454A2004EF308 /* Vignette.metal */,
 				795ECA7921E90944000EF927 /* ZoomBlur.swift */,
 				795ECA7C21E9095A000EF927 /* ZoomBlur.metal */,
+				FB10DA6E2AF8F688000B1AEF /* Grain.swift */,
+				FB10DA6D2AF8F688000B1AEF /* Grain.metal */,
 			);
 			name = Effects;
 			sourceTree = "<group>";
@@ -1134,6 +1142,7 @@
 				79CB6E0B21092E3E0042F87B /* LuminosityBlend.metal in Sources */,
 				79CB6DEA210926220042F87B /* ExclusionBlend.swift in Sources */,
 				79CB6E0221092D710042F87B /* LinearBurnBlend.swift in Sources */,
+				FB10DA712AF8F688000B1AEF /* Grain.swift in Sources */,
 				79CB6DCF2108B1BC0042F87B /* ColorBurnBlend.metal in Sources */,
 				7B25C0E32103D328000EC621 /* AlphaBlend.swift in Sources */,
 				795ECAB421EF8ECA000EF927 /* ChromaKey.swift in Sources */,
@@ -1141,6 +1150,7 @@
 				79A81CA021010A2200A3B43A /* Vibrance.swift in Sources */,
 				4C280F76213426D6001A985C /* Posterize.swift in Sources */,
 				79CB6E112109311C0042F87B /* MultiplyBlend.metal in Sources */,
+				FB10DA6F2AF8F688000B1AEF /* Grain.metal in Sources */,
 				BC7BA28420F59C8E006B5F4B /* MonochromeFilter.metal in Sources */,
 				FBE32DE42760CA9400DDDE68 /* UnsharpMask.swift in Sources */,
 				79CB6E20210A07F30042F87B /* SaturationBlend.swift in Sources */,
@@ -1341,6 +1351,7 @@
 				79CB6E0C21092E3E0042F87B /* LuminosityBlend.metal in Sources */,
 				79CB6DEB210926220042F87B /* ExclusionBlend.swift in Sources */,
 				79CB6E0321092D710042F87B /* LinearBurnBlend.swift in Sources */,
+				FB10DA722AF8F688000B1AEF /* Grain.swift in Sources */,
 				79CB6DD02108B1BC0042F87B /* ColorBurnBlend.metal in Sources */,
 				7B25C0E42103D328000EC621 /* AlphaBlend.swift in Sources */,
 				795ECAB521EF8ECA000EF927 /* ChromaKey.swift in Sources */,
@@ -1348,6 +1359,7 @@
 				79A81CA121010A2200A3B43A /* Vibrance.swift in Sources */,
 				4C280F77213426D6001A985C /* Posterize.swift in Sources */,
 				79CB6E122109311C0042F87B /* MultiplyBlend.metal in Sources */,
+				FB10DA702AF8F688000B1AEF /* Grain.metal in Sources */,
 				BCE0BE9F20D6E3C80006E120 /* Color.swift in Sources */,
 				FBE32DE52760CA9400DDDE68 /* UnsharpMask.swift in Sources */,
 				79CB6E21210A07F30042F87B /* SaturationBlend.swift in Sources */,

--- a/framework/Source/Operations/Grain.metal
+++ b/framework/Source/Operations/Grain.metal
@@ -1,0 +1,105 @@
+//
+//  Grain.metal
+//  GPUImage
+//
+//  Created by Jim Wang on 2023/11/6.
+//  Copyright © 2023 Red Queen Coder, LLC. All rights reserved.
+//
+
+#include <metal_stdlib>
+#include "OperationShaderTypes.h"
+using namespace metal;
+
+half3 channel_mix(half3 a, half3 b, half3 w) {
+    return mix(a, b, w);
+}
+
+float gaussian(float z, float u, float o) {
+    float pi = 3.14159265358979323846;
+    return (1.0 / (o * sqrt(2.0 * pi))) * exp(-(((z - u) * (z - u)) / (2.0 * (o * o))));
+}
+
+half3 madd(half3 a, half3 b, float w) {
+    return a + a * b * w;
+}
+
+half3 screen(half3 a, half3 b, float w) {
+    return mix(a, 1.0 - ((1.0 - a) * (1.0 - b)), w);
+}
+
+half3 overlay(half3 a, half3 b, float w) {
+    return mix(a, channel_mix(2.0 * a * b, 1.0 - 2.0 * (1.0 - a) * (1.0 - b), step(0.5, a)), w);
+}
+
+half3 soft_light(half3 a, half3 b, float w) {
+    return mix(a, pow(a, half3(2.0 * (0.5 - b))), half3(w));
+}
+
+struct GrainUniform {
+    // 0: true
+    // 1: false
+    float sRGB;
+    // 0 ~ 1
+    float strength;
+    // 0 ~ 1
+    float scale;
+    //
+    float time;
+    // 1: screen
+    // 2: overlay
+    // 3: soft_light
+    // 4: max(textureColor.rgb, grain * strength)
+    // others: grain * strength;
+    float blendMode;
+};
+
+fragment half4 grainEffectFragment(SingleInputVertexIO fragmentInput [[stage_in]],
+                                   texture2d<half> inputTexture [[texture(0)]],
+                                   constant GrainUniform& uniform [[buffer(1)]])
+{
+    constexpr sampler quadSampler;
+    float2 uv = fragmentInput.textureCoordinate / uniform.scale;
+
+    // Sample the input texture
+    half4 textureColor = inputTexture.sample(quadSampler, uv);
+
+    // Calculate UV coordinates scaled by 'scale'
+    uv /= uniform.scale;
+
+    // Apply sRGB correction if needed
+    if (uniform.sRGB == 1) {
+        textureColor.rgb = pow(textureColor.rgb, 2.2);
+    }
+
+    // Calculate noise
+    float mean = 0.0;
+    float variance = 0.5;
+    float t = uniform.time;
+    float seed = dot(uv, float2(12.9898, 78.233));
+    float noise = fract(sin(seed) * 43758.5453 + t);
+    noise = gaussian(noise, mean, variance * variance);
+
+    // Calculate grain
+    half3 grain = half3(noise) * (1.0 - textureColor.rgb);
+    grain *= 2.0;
+
+    // Apply blending modes
+    if (uniform.blendMode == 1) {
+        textureColor.rgb = screen(textureColor.rgb, grain, uniform.strength);
+    } else if (uniform.blendMode == 2) {
+        textureColor.rgb = overlay(textureColor.rgb, grain, uniform.strength);
+    } else if (uniform.blendMode == 3) {
+        textureColor.rgb = soft_light(textureColor.rgb, grain, uniform.strength);
+    } else if (uniform.blendMode == 4) {
+        textureColor.rgb = max(textureColor.rgb, grain * uniform.strength);
+    } else {
+        textureColor.rgb += grain * uniform.strength;
+    }
+
+    // Apply sRGB correction if needed
+    if (uniform.sRGB == 1) {
+        textureColor.rgb = pow(textureColor.rgb, 1.0 / 2.2);
+    }
+
+    return textureColor;
+}

--- a/framework/Source/Operations/Grain.swift
+++ b/framework/Source/Operations/Grain.swift
@@ -1,0 +1,26 @@
+//
+//  Grain.swift
+//  GPUImage
+//
+//  Created by Jim Wang on 2023/11/6.
+//  Copyright © 2023 Red Queen Coder, LLC. All rights reserved.
+//
+
+import Foundation
+
+public class Grain: BasicOperation {
+    public var isSRGB: Float = 0 { didSet { uniformSettings["sRGB"] = isSRGB } }
+    public var strength: Float = 0.1 { didSet { uniformSettings["strength"] = strength } }
+    public var scale: Float = 1.0 { didSet { uniformSettings["scale"] = scale } }
+    public var time: Float = 1.1 { didSet { uniformSettings["time"] = time } }
+    public var blendMode: Float = 0.0 { didSet { uniformSettings["blendMode"] = blendMode } }
+
+    public init() {
+        super.init(fragmentFunctionName:"grainEffectFragment", numberOfInputs:1)
+        ({isSRGB = 0.0})()
+        ({strength = 0.1})()
+        ({scale = 1.0})()
+        ({time = 1.1})()
+        ({blendMode = 0.0})()
+    }
+}


### PR DESCRIPTION
# Description

Implement the Grain filter effect.

The shader is referenced from [CBVisualEffectBuiltins - Grain2](https://github.com/cardinalblue/CBVisualEffectBuiltins/blob/dev/Example/MetalVisualEffect/Grain2/Grain2.metal) which was originally implemented in C style and has now been converted into a Metal shader.