### PR TITLE
:recycle: add a flag to skip caching textures

### DIFF
--- a/framework/Source/PictureInput.swift
+++ b/framework/Source/PictureInput.swift
@@ -11,13 +11,16 @@ public class PictureInput: ImageSource {
     var hasProcessedImage:Bool = false
     var internalImage:CGImage?
 
-    public init(image:CGImage, smoothlyScaleOutput:Bool = false, orientation:ImageOrientation = .portrait) {
+    let isTransient: Bool
+
+    public init(image:CGImage, smoothlyScaleOutput:Bool = false, orientation:ImageOrientation = .portrait, isTransient: Bool = false) {
         internalImage = image
+        self.isTransient = isTransient
     }
     
     #if canImport(UIKit)
-    public convenience init(image:UIImage, smoothlyScaleOutput:Bool = false, orientation:ImageOrientation = .portrait) {
-        self.init(image: image.cgImage!, smoothlyScaleOutput: smoothlyScaleOutput, orientation: orientation)
+    public convenience init(image:UIImage, smoothlyScaleOutput:Bool = false, orientation:ImageOrientation = .portrait, isTransient: Bool = false) {
+        self.init(image: image.cgImage!, smoothlyScaleOutput: smoothlyScaleOutput, orientation: orientation, isTransient: isTransient)
     }
     
     public convenience init(imageName:String, smoothlyScaleOutput:Bool = false, orientation:ImageOrientation = .portrait) {
@@ -53,7 +56,11 @@ public class PictureInput: ImageSource {
                 do {
                     let imageTexture = try textureLoader.newTexture(cgImage:internalImage!, options: [MTKTextureLoader.Option.SRGB : false])
                     internalImage = nil
-                    self.internalTexture = Texture(orientation: .portrait, texture: imageTexture)
+                    self.internalTexture = Texture(
+                        orientation: .portrait,
+                        texture: imageTexture,
+                        timingStyle: isTransient ? .transientImage : .stillImage
+                    )
                     self.updateTargetsWithTexture(self.internalTexture!)
                     self.hasProcessedImage = true
                 } catch {
@@ -64,7 +71,11 @@ public class PictureInput: ImageSource {
                     guard (error == nil) else { fatalError("Error in loading texture: \(error!)") }
                     guard let texture = possibleTexture else { fatalError("Nil texture received") }
                     self.internalImage = nil
-                    self.internalTexture = Texture(orientation: .portrait, texture: texture)
+                    self.internalTexture = Texture(
+                        orientation: .portrait,
+                        texture: texture,
+                        timingStyle: self.isTransient ? .transientImage : .stillImage
+                    )
                     DispatchQueue.global().async{
                         self.updateTargetsWithTexture(self.internalTexture!)
                         self.hasProcessedImage = true

--- a/framework/Source/PictureInput.swift
+++ b/framework/Source/PictureInput.swift
@@ -67,7 +67,8 @@ public class PictureInput: ImageSource {
                     fatalError("Failed loading image texture")
                 }
             } else {
-                textureLoader.newTexture(cgImage: internalImage!, options: [MTKTextureLoader.Option.SRGB : false], completionHandler: { (possibleTexture, error) in
+                textureLoader.newTexture(cgImage: internalImage!, options: [MTKTextureLoader.Option.SRGB : false], completionHandler: { [weak self] (possibleTexture, error) in
+                    guard let self else { return }
                     guard (error == nil) else { fatalError("Error in loading texture: \(error!)") }
                     guard let texture = possibleTexture else { fatalError("Nil texture received") }
                     self.internalImage = nil

--- a/framework/Source/Texture.swift
+++ b/framework/Source/Texture.swift
@@ -6,19 +6,21 @@ import UIKit
 
 public enum TextureTimingStyle {
     case stillImage
+    case transientImage
     case videoFrame(timestamp:Timestamp)
     
     func isTransient() -> Bool {
         switch self {
         case .stillImage: return false
         case .videoFrame: return true
+        case .transientImage: return true
         }
     }
     
     var timestamp:Timestamp? {
         get {
             switch self {
-            case .stillImage: return nil
+            case .stillImage, .transientImage: return nil
             case let .videoFrame(timestamp): return timestamp
             }
         }


### PR DESCRIPTION
## Descriptions:
- Add a new input type to disable caching textures for all filters
- Filters in GPUImage3 will create texture with a TextureTimingStyle Inherited from the original one, so it will work as expected by setting the TextureTimingStyle on ImageInput

## Discuss:
- These changes will impact all effect types in PicCollage, rather than only impact the Kirakira effect. 
- This is because we have to set up ImageInput in the ImageEffectService.
- I have tested the behavior for other imageEffects, and both the result and memory usage look fine with these changes.
- For the changes, please see here [⚡ Skip to cache the texture in GPUImage](https://github.com/cardinalblue/pic-collage-ios/pull/7844/commits/ef378d1505923d31e8d585a8305807ec1882d128)