### PR TITLE
:sparkles: kirakira effect normalization

### DIFF
--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Barbie.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Barbie.json
@@ -74,5 +74,13 @@
     "frameRate" : {
         "type" : "int",
         "value" : 60
-    }
+    },
+    "maxLength" : {
+        "type" : "int",
+        "value" : 1000
+    },
+    "sparkleScale" : {
+        "type" : "float",
+        "value" : 0.7
+    },
 }

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Barbie.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Barbie.json
@@ -75,9 +75,9 @@
         "type" : "int",
         "value" : 60
     },
-    "maxLength" : {
+    "targetDimension" :{
         "type" : "int",
-        "value" : 1000
+        "value" : 1024
     },
     "sparkleScale" : {
         "type" : "float",

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Diamond.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Diamond.json
@@ -74,5 +74,13 @@
     "frameRate" : {
         "type" : "int",
         "value" : 60
-    }
+    },
+    "maxLength" : {
+        "type" : "int",
+        "value" : 1000
+    },
+    "sparkleScale" : {
+        "type" : "float",
+        "value" : 0.7
+    },
 }

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Diamond.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Diamond.json
@@ -75,9 +75,9 @@
         "type" : "int",
         "value" : 60
     },
-    "maxLength" : {
+    "targetDimension" :{
         "type" : "int",
-        "value" : 1000
+        "value" : 1024
     },
     "sparkleScale" : {
         "type" : "float",

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Flashlight.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Flashlight.json
@@ -74,5 +74,13 @@
     "frameRate" : {
         "type" : "int",
         "value" : 60
-    }
+    },
+    "maxLength" : {
+        "type" : "int",
+        "value" : 1000
+    },
+    "sparkleScale" : {
+        "type" : "float",
+        "value" : 0.7
+    },
 }

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Flashlight.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Flashlight.json
@@ -75,9 +75,9 @@
         "type" : "int",
         "value" : 60
     },
-    "maxLength" : {
+    "targetDimension" :{
         "type" : "int",
-        "value" : 1000
+        "value" : 1024
     },
     "sparkleScale" : {
         "type" : "float",

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Glamour.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Glamour.json
@@ -74,5 +74,13 @@
     "frameRate" : {
         "type" : "int",
         "value" : 60
-    }
+    },
+    "maxLength" : {
+        "type" : "int",
+        "value" : 1000
+    },
+    "sparkleScale" : {
+        "type" : "float",
+        "value" : 0.7
+    },
 }

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Glamour.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Glamour.json
@@ -75,9 +75,9 @@
         "type" : "int",
         "value" : 60
     },
-    "maxLength" : {
+    "targetDimension" :{
         "type" : "int",
-        "value" : 1000
+        "value" : 1024
     },
     "sparkleScale" : {
         "type" : "float",

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Golden.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Golden.json
@@ -74,5 +74,13 @@
     "frameRate" : {
         "type" : "int",
         "value" : 60
-    }
+    },
+    "maxLength" : {
+        "type" : "int",
+        "value" : 1000
+    },
+    "sparkleScale" : {
+        "type" : "float",
+        "value" : 0.7
+    },
 }

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Golden.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Golden.json
@@ -75,9 +75,9 @@
         "type" : "int",
         "value" : 60
     },
-    "maxLength" : {
+    "targetDimension" :{
         "type" : "int",
-        "value" : 1000
+        "value" : 1024
     },
     "sparkleScale" : {
         "type" : "float",

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Rainbow.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Rainbow.json
@@ -74,5 +74,13 @@
     "frameRate" : {
         "type" : "int",
         "value" : 60
-    }
+    },
+    "maxLength" : {
+        "type" : "int",
+        "value" : 1000
+    },
+    "sparkleScale" : {
+        "type" : "float",
+        "value" : 0.7
+    },
 }

--- a/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Rainbow.json
+++ b/examples/iOS/SimpleImageFilter/SimpleImageFilter/Kirakira_Rainbow.json
@@ -75,9 +75,9 @@
         "type" : "int",
         "value" : 60
     },
-    "maxLength" : {
+    "targetDimension" :{
         "type" : "int",
-        "value" : 1000
+        "value" : 1024
     },
     "sparkleScale" : {
         "type" : "float",

--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		7B72DB2C2103CED000A91156 /* AddBlend.metal in Sources */ = {isa = PBXBuildFile; fileRef = 7B72DB2A2103CED000A91156 /* AddBlend.metal */; };
 		93290EDC2BD902F900028F31 /* DirectionalShine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93290EDA2BD902F900028F31 /* DirectionalShine.swift */; };
 		93879E302BDA4FD100D6E5FD /* Sparkles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93879E2F2BDA4FD100D6E5FD /* Sparkles.swift */; };
+		9394938C2BE3CFD1006FF4D1 /* CBRescaleEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9394938B2BE3CFD1006FF4D1 /* CBRescaleEffect.swift */; };
 		93C331A22BD7AA9F00196F25 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 93C331A02BD7AA9E00196F25 /* Utils.h */; };
 		93C331A32BD7AA9F00196F25 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 93C331A02BD7AA9E00196F25 /* Utils.h */; };
 		93C331A42BD7AA9F00196F25 /* Utils.metal in Sources */ = {isa = PBXBuildFile; fileRef = 93C331A12BD7AA9F00196F25 /* Utils.metal */; };
@@ -607,6 +608,7 @@
 		7B72DB2A2103CED000A91156 /* AddBlend.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; name = AddBlend.metal; path = Source/Operations/AddBlend.metal; sourceTree = "<group>"; };
 		93290EDA2BD902F900028F31 /* DirectionalShine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DirectionalShine.swift; path = Source/DirectionalShine.swift; sourceTree = "<group>"; };
 		93879E2F2BDA4FD100D6E5FD /* Sparkles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Sparkles.swift; path = Source/Sparkles.swift; sourceTree = "<group>"; };
+		9394938B2BE3CFD1006FF4D1 /* CBRescaleEffect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CBRescaleEffect.swift; path = Source/Operations/CBRescaleEffect.swift; sourceTree = "<group>"; };
 		93C331A02BD7AA9E00196F25 /* Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Utils.h; path = Source/Operations/Utils.h; sourceTree = "<group>"; };
 		93C331A12BD7AA9F00196F25 /* Utils.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; name = Utils.metal; path = Source/Operations/Utils.metal; sourceTree = "<group>"; };
 		96F24FED22007D6C0042E78D /* MedianFilter.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; name = MedianFilter.metal; path = Source/Operations/MedianFilter.metal; sourceTree = "<group>"; };
@@ -1002,6 +1004,7 @@
 				FBC104EE2BB6A35F00FA0885 /* CBKirakiraLightExtractor.swift */,
 				FBFD6C662BD690E70068909D /* CBPerlineNoise.metal */,
 				FBC104F32BB6A35F00FA0885 /* CBPerlineNoise.swift */,
+				9394938B2BE3CFD1006FF4D1 /* CBRescaleEffect.swift */,
 				93290EDA2BD902F900028F31 /* DirectionalShine.swift */,
 			);
 			name = CB;
@@ -1347,6 +1350,7 @@
 				FBC105022BB6A36000FA0885 /* CBPerlineNoise.swift in Sources */,
 				795ECA7421E903E2000EF927 /* ToonFilter.swift in Sources */,
 				BC25F8AF22C2B3F700CBBD15 /* HighPassFilter.swift in Sources */,
+				9394938C2BE3CFD1006FF4D1 /* CBRescaleEffect.swift in Sources */,
 				795ECAC021EF95EB000EF927 /* LocalBinaryPattern.swift in Sources */,
 				799999832226FE8F007404F2 /* KuwaharaRadius3Filter.swift in Sources */,
 				79CB6DE42108CC460042F87B /* DivideBlend.swift in Sources */,

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -36,7 +36,7 @@ public class Kirakira: OperationGroup {
         public var sparkleAmount: Float
         public var frameRate: Float
         public var blur: Int
-        public var maxLength: Int
+        public var targetDimension: Int
 
         public init(
             colorMode: ColorMode = .random,
@@ -59,7 +59,7 @@ public class Kirakira: OperationGroup {
             sparkleAmount: Float = 0.6,
             frameRate: Float = 60,
             blur: Int = 0,
-            maxLength: Int = 1000
+            targetDimension: Int = 1024
         ) {
             self.colorMode = colorMode
             self.saturation = saturation
@@ -81,14 +81,14 @@ public class Kirakira: OperationGroup {
             self.sparkleAmount = sparkleAmount
             self.frameRate = frameRate
             self.blur = blur
-            self.maxLength = maxLength
+            self.targetDimension =             targetDimension
         }
     }
 
     // MARK: Properties
 
-    public var maxLength: Int = 1000 {
-        didSet { blendImageRescaleEffect.maxLength = maxLength }
+    public var targetDimension: Int = 1024 {
+        didSet { blendImageRescaleEffect.targetDimension = targetDimension }
     }
     public var colorMode: ColorMode = .random {
         didSet {
@@ -170,7 +170,7 @@ public class Kirakira: OperationGroup {
 
         ({
             colorMode = parameters.colorMode
-            maxLength = parameters.maxLength
+            targetDimension = parameters.targetDimension
             saturation = parameters.saturation
             centerSaturation = parameters.centerSaturation
             equalMinHue = parameters.equalMinHue
@@ -248,7 +248,7 @@ extension Kirakira.Parameters: Decodable {
         case sparkleAmount
         case frameRate
         case sparkleScale
-        case maxLength
+        case targetDimension
     }
 
     public init(from decoder: Decoder) throws {
@@ -273,7 +273,7 @@ extension Kirakira.Parameters: Decodable {
         sparkleAmount = try container.decodeParamValue(Float.self, forKey: .sparkleAmount)
         frameRate = try container.decodeParamValue(Float.self, forKey: .frameRate)
         sparkleScale = try container.decodeParamValue(Float.self, forKey: .sparkleScale)
-        maxLength = try container.decodeParamValue(Int.self, forKey: .maxLength)
+        targetDimension = try container.decodeParamValue(Int.self, forKey: .targetDimension)
     }
 }
 

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -88,10 +88,7 @@ public class Kirakira: OperationGroup {
     // MARK: Properties
 
     public var maxLength: Int = 1000 {
-        didSet {
-            blendImageRescaleEffect.maxLength = maxLength
-            sourceImageRescaleEffect.maxLength = maxLength
-        }
+        didSet { blendImageRescaleEffect.maxLength = maxLength }
     }
     public var colorMode: ColorMode = .random {
         didSet {
@@ -161,7 +158,6 @@ public class Kirakira: OperationGroup {
     // MARK: Effects
 
     private let blendImageRescaleEffect = CBRescaleEffect()
-    private let sourceImageRescaleEffect = CBRescaleEffect()
     private let sparklesEffect: Sparkles
     private let blurEffect = GaussianBlur()
     private let saturationEffect = SaturationAdjustment()
@@ -204,7 +200,6 @@ public class Kirakira: OperationGroup {
             saturationEffect.addTarget(addBlend, atTargetIndex: 1)
 
             input
-            --> sourceImageRescaleEffect
             --> addBlend
             --> output
         }

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -249,6 +249,7 @@ extension Kirakira.Parameters: Decodable {
         case frameRate
         case sparkleScale
         case maxLength
+        case sparkleScale
     }
 
     public init(from decoder: Decoder) throws {

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -81,7 +81,7 @@ public class Kirakira: OperationGroup {
             self.sparkleAmount = sparkleAmount
             self.frameRate = frameRate
             self.blur = blur
-            self.targetDimension =             targetDimension
+            self.targetDimension = targetDimension
         }
     }
 

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -249,7 +249,6 @@ extension Kirakira.Parameters: Decodable {
         case frameRate
         case sparkleScale
         case maxLength
-        case sparkleScale
     }
 
     public init(from decoder: Decoder) throws {

--- a/framework/Source/Operations/CBRescaleEffect.swift
+++ b/framework/Source/Operations/CBRescaleEffect.swift
@@ -1,0 +1,75 @@
+//
+//  CBRescaleEffect.swift
+//
+//
+//  Created by Chiaote Ni on 2024/5/2.
+//
+
+import Foundation
+import Metal
+
+public class CBRescaleEffect: BasicOperation {
+    // 0 ~ 4000
+    public var targetWidth: Int = 1000
+    // 0 ~ 4000
+    public var targetHeight: Int = 1000
+    // 0 ~ 4000
+    public var maxLength: Int = 1000
+
+    public init() {
+        super.init(fragmentFunctionName: "passthroughFragment", numberOfInputs: 1)
+    }
+
+    public override func newTextureAvailable(_ texture: Texture, fromSourceIndex: UInt) {
+        guard fromSourceIndex == 0 else {
+            assertionFailure("sourceIndex out of range")
+            return
+        }
+        guard let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer() else {
+            return
+        }
+
+        defer {
+            textureInputSemaphore.signal()
+        }
+        let _ = textureInputSemaphore.wait(timeout:DispatchTime.distantFuture)
+        
+        let outputSize = calculateTargetSize(from: texture)
+        let outputTexture = Texture(
+            device: sharedMetalRenderingDevice.device,
+            orientation: texture.orientation,
+            pixelFormat: texture.texture.pixelFormat,
+            width: Int(outputSize.width),
+            height: Int(outputSize.height),
+            timingStyle: texture.timingStyle
+        )
+
+        inputTextures[0] = texture
+        internalRenderFunction(commandBuffer: commandBuffer, outputTexture: outputTexture)
+        commandBuffer.commit()
+
+        removeTransientInputs()
+        updateTargetsWithTexture(outputTexture)
+    }
+
+    private func calculateTargetSize(from texture: Texture) -> CGSize {
+        let textureSize = CGSize(
+            width: CGFloat(texture.texture.width),
+            height: CGFloat(texture.texture.height)
+        )
+        let textureMaxLength = max(textureSize.width, textureSize.height)
+
+        let widthResizeRatio = maxLength > 0
+        ? CGFloat(maxLength) / textureMaxLength
+        : min(1.0, CGFloat(targetWidth) / CGFloat(textureSize.width))
+
+        let heightResizeRatio = maxLength > 0
+        ? CGFloat(maxLength) / textureMaxLength
+        : min(1.0, CGFloat(targetHeight) / CGFloat(textureSize.height))
+
+        let width = textureSize.width * widthResizeRatio
+        let height = textureSize.height * heightResizeRatio
+
+        return CGSize(width: width, height: height)
+    }
+}

--- a/framework/Source/Operations/CBRescaleEffect.swift
+++ b/framework/Source/Operations/CBRescaleEffect.swift
@@ -25,10 +25,10 @@ public class CBRescaleEffect: BasicOperation {
             return
         }
 
+        let _ = textureInputSemaphore.wait(timeout:DispatchTime.distantFuture)
         defer {
             textureInputSemaphore.signal()
         }
-        let _ = textureInputSemaphore.wait(timeout:DispatchTime.distantFuture)
         
         let outputSize = calculateTargetSize(from: texture)
         let outputTexture = Texture(

--- a/framework/Source/Operations/CBRescaleEffect.swift
+++ b/framework/Source/Operations/CBRescaleEffect.swift
@@ -9,11 +9,11 @@ import Foundation
 import Metal
 
 public class CBRescaleEffect: BasicOperation {
-    // 0 ~ 4000
+    // 1 ~ 4000
     public var targetWidth: Int = 1000
-    // 0 ~ 4000
+    // 1 ~ 4000
     public var targetHeight: Int = 1000
-    // 0 ~ 4000
+    // 1 ~ 4000
     public var maxLength: Int = 1000
 
     public init() {

--- a/framework/Source/Operations/CBRescaleEffect.swift
+++ b/framework/Source/Operations/CBRescaleEffect.swift
@@ -10,11 +10,7 @@ import Metal
 
 public class CBRescaleEffect: BasicOperation {
     // 1 ~ 4000
-    public var targetWidth: Int = 1000
-    // 1 ~ 4000
-    public var targetHeight: Int = 1000
-    // 1 ~ 4000
-    public var maxLength: Int = 1000
+    public var targetDimension: Int = 1024
 
     public init() {
         super.init(fragmentFunctionName: "passthroughFragment", numberOfInputs: 1)
@@ -57,15 +53,9 @@ public class CBRescaleEffect: BasicOperation {
             width: CGFloat(texture.texture.width),
             height: CGFloat(texture.texture.height)
         )
-        let textureMaxLength = max(textureSize.width, textureSize.height)
-
-        let widthResizeRatio = maxLength > 0
-        ? CGFloat(maxLength) / textureMaxLength
-        : min(1.0, CGFloat(targetWidth) / CGFloat(textureSize.width))
-
-        let heightResizeRatio = maxLength > 0
-        ? CGFloat(maxLength) / textureMaxLength
-        : min(1.0, CGFloat(targetHeight) / CGFloat(textureSize.height))
+        let textureTargetDimension = max(textureSize.width, textureSize.height)
+        let widthResizeRatio = targetDimension > 0 ? CGFloat(targetDimension) / textureTargetDimension : 1.0
+        let heightResizeRatio = targetDimension > 0 ? CGFloat(targetDimension) / textureTargetDimension : 1.0
 
         let width = textureSize.width * widthResizeRatio
         let height = textureSize.height * heightResizeRatio


### PR DESCRIPTION
## Descriptions:
- This is the extended PR of the https://github.com/cardinalblue/GPUImage3/pull/9; the original one has closed automatically by rebasing the branch with dropping some of the comments.
- Please feel free to review the last commit directly [♻️ refactor the normalization and rename the maxLength to targetDimen…](https://github.com/cardinalblue/GPUImage3/commit/27125ee447d2c63b7d1c9b7723a3d40054ddc74c), all other ones have already been reviewed in the original PR.

- Implement kirakira effect normalization based on the changes in the branch [kirakira_normalization] (https://github.com/cardinalblue/CBVisualEffectBuiltins/compare/dev...task/kirakira_normalization) in CBVisualEffectBuiltIn
- Also, based on the changes in the branch [kirakira_normalization](https://github.com/cardinalblue/CBVisualEffectBuiltins/compare/dev...task/kirakira_normalization), I modified some default values for the parameters as well

# Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![IMG_9700](https://github.com/cardinalblue/GPUImage3/assets/40178645/103008c5-5de8-4299-804a-05d4b37951fd)

</td>
<td>

![IMG_9697](https://github.com/cardinalblue/GPUImage3/assets/40178645/97afaba0-72f4-4a0e-8859-24db6805c0e0)

</td>
</tr>
</table>
