### PR TITLE
:sparkles: public the time from perlinNoise filter

### DIFF
--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -151,8 +151,8 @@ public class Kirakira: OperationGroup {
     public var frameRate: Float = 60 {
         didSet { sparklesEffect.frameRate = frameRate }
     }
-    public var time: Float = 0 {
-        didSet { sparklesEffect.time = time }
+    public var seed: Float = 0 {
+        didSet { sparklesEffect.time = seed }
     }
     // For the blur effect
     public var blur: Int = 0 {

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -151,6 +151,9 @@ public class Kirakira: OperationGroup {
     public var frameRate: Float = 60 {
         didSet { sparklesEffect.frameRate = frameRate }
     }
+    public var time: Float = 0 {
+        didSet { sparklesEffect.time = time }
+    }
     // For the blur effect
     public var blur: Int = 0 {
         didSet { blurEffect.blurRadiusInPixels = Float(blur) }

--- a/framework/Source/Sparkles.swift
+++ b/framework/Source/Sparkles.swift
@@ -24,6 +24,9 @@ public class Sparkles: OperationGroup {
     public var frameRate: Float = 60 {
         didSet { perlinNoiseEffect.frameRate = frameRate }
     }
+    public var time: Float = 0 {
+        didSet { perlinNoiseEffect.time = time }
+    }
     // LightExtractor
     public var equalMinHue: Float = 0.75 {
         didSet { lightExtractorEffect.equalMinHue = equalMinHue }


### PR DESCRIPTION
# Description

- Like the title suggests, we decide to public the `time` as a parameter of the kirakira effect

# Screenshots

<video src=https://github.com/cardinalblue/pic-collage-ios/assets/40178645/39058425-3760-45ad-a13a-e1cac54460b9 width=300>