### PR TITLE
feat: adjust the light map extractor

### DIFF
--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -30,7 +30,6 @@ public class Kirakira: OperationGroup {
         public var sparkleExposure: Float
         public var minHue: Float
         public var maxHue: Float
-        public var noiseInfluence: Float
         public var increasingRate: Float
         public var sparkleAmount: Float
         public var frameRate: Float
@@ -52,7 +51,6 @@ public class Kirakira: OperationGroup {
             sparkleExposure: Float = 0.1,
             minHue: Float = 0.0,
             maxHue: Float = 1.0,
-            noiseInfluence: Float = 1.0,
             increasingRate: Float = 0.03,
             sparkleAmount: Float = 1.0,
             frameRate: Float = 60,
@@ -73,7 +71,6 @@ public class Kirakira: OperationGroup {
             self.sparkleExposure = sparkleExposure
             self.minHue = minHue
             self.maxHue = maxHue
-            self.noiseInfluence = noiseInfluence
             self.increasingRate = increasingRate
             self.sparkleAmount = sparkleAmount
             self.frameRate = frameRate
@@ -138,9 +135,6 @@ public class Kirakira: OperationGroup {
     public var maxHue: Float = 1.0 {
         didSet { sparklesEffect.maxHue = maxHue }
     }
-    public var noiseInfluence: Float = 1.0 {
-        didSet { sparklesEffect.noiseInfluence = noiseInfluence }
-    }
     public var increasingRate: Float = 0.3 {
         didSet { sparklesEffect.increasingRate = increasingRate }
     }
@@ -198,7 +192,6 @@ public class Kirakira: OperationGroup {
             sparkleExposure = parameters.sparkleExposure
             minHue = parameters.minHue
             maxHue = parameters.maxHue
-            noiseInfluence = parameters.noiseInfluence
             increasingRate = parameters.increasingRate
             sparkleAmount = parameters.sparkleAmount
             frameRate = parameters.frameRate
@@ -280,7 +273,6 @@ extension Kirakira.Parameters: Decodable {
         centerSaturation = try container.decodeParamValue(Float.self, forKey: .centerSaturation)
         minHue = try container.decodeParamValue(Float.self, forKey: .minHue)
         maxHue = try container.decodeParamValue(Float.self, forKey: .maxHue)
-        noiseInfluence = try container.decodeParamValue(Float.self, forKey: .noiseInfluence)
         increasingRate = try container.decodeParamValue(Float.self, forKey: .increasingRate)
         startAngle = try container.decodeParamValue(Int.self, forKey: .startAngle)
         sparkleAmount = try container.decodeParamValue(Float.self, forKey: .sparkleAmount)

--- a/framework/Source/Operations/CBKirakiraLightExtractor.metal
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.metal
@@ -15,7 +15,6 @@ struct LightExtractorUniform {
     float luminanceThreshold;
     float gapThreshold;
     float noiseThreshold;
-    float noiseInfluence;
     float increasingRate;
     float minHue;
     float maxHue;
@@ -83,15 +82,12 @@ fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput
     outputValue = count > 3.0 ? luminance : 0.0;
 
     // Apply threshold on noise texture
-    noiseColor.r = noiseColor.r < uniform.noiseThreshold
-                    ? (pow(1.0 - (uniform.noiseThreshold - noiseColor.r) / uniform.noiseThreshold, 2.0)) * noiseColor.r
-                    : noiseColor.r;
+    noiseColor.r = noiseColor.r < uniform.noiseThreshold ? 0.0 : 1.0;
 
     // Increase the appearance probability of the bright area
     float increaseValue = luminance > (uniform.luminanceThreshold) * 1.1 ? ((rand(uv) - (1.0 - uniform.increasingRate)) * 0.5) : 0.0;
     increaseValue = clamp(increaseValue, 0.0, 1.0);
     noiseColor.r += increaseValue;
-    noiseColor.r = mix(1.0, noiseColor.r, uniform.noiseInfluence);
 
     outputValue *= noiseColor.r;
 

--- a/framework/Source/Operations/CBKirakiraLightExtractor.swift
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.swift
@@ -22,10 +22,6 @@ public class CBKirakiraLightExtractor: BasicOperation {
         didSet { uniformSettings["noiseThreshold"] = noiseThreshold }
     }
     // 0.0 ~ 1.0
-    public var noiseInfluence: Float = 1.0 {
-        didSet { uniformSettings["noiseInfluence"] = noiseInfluence }
-    }
-    // 0.0 ~ 1.0
     public var increasingRate: Float = 0.3 {
         didSet { uniformSettings["increasingRate"] = increasingRate }
     }
@@ -60,7 +56,6 @@ public class CBKirakiraLightExtractor: BasicOperation {
             luminanceThreshold = 0.8
             gapThreshold = 0.2
             noiseThreshold = 0.8
-            noiseInfluence = 1.0
             increasingRate = 0.3
             minHue = 0.0
             maxHue = 1.0

--- a/framework/Source/Operations/CBPerlineNoise.metal
+++ b/framework/Source/Operations/CBPerlineNoise.metal
@@ -112,7 +112,7 @@ fragment float4 perlineNoiseFragment(SingleInputVertexIO fragmentInput [[ stage_
     value = 0.2 + 0.8*value;
 
     // Enhance the difference
-    value = pow(value + 0.5, 5.0) - 0.5;
+    value = pow(value + 0.5, 1.5) - 0.5;
 
     return float4(float3(value), inputColor.a);
 }

--- a/framework/Source/Sparkles.swift
+++ b/framework/Source/Sparkles.swift
@@ -46,14 +46,14 @@ public class Sparkles: OperationGroup {
     public var maxHue: Float = 1.0 {
         didSet { lightExtractorEffect.maxHue = maxHue }
     }
-    public var noiseInfluence: Float = 1.0 {
-        didSet { lightExtractorEffect.noiseInfluence = noiseInfluence }
-    }
     public var increasingRate: Float = 0.3 {
         didSet { lightExtractorEffect.increasingRate = increasingRate }
     }
     public var sparkleAmount: Float = 1.0 {
-        didSet { lightExtractorEffect.luminanceThreshold = 1.0 - sparkleAmount * 0.5}
+        didSet {
+            lightExtractorEffect.luminanceThreshold = 1.0 - sparkleAmount * 0.5
+            lightExtractorEffect.noiseThreshold = sparkleAmount == 0.0 ? 1.0 : 0.2 * (1.0 - sparkleAmount) + 0.3
+        }
     }
     // DirectionalBlurs
     public var rayLength: Float = 0.08 {
@@ -126,7 +126,6 @@ public class Sparkles: OperationGroup {
         ({sparkleExposure = 0.0})()
         ({minHue = 0.0})()
         ({maxHue = 1.0})()
-        ({noiseInfluence = 1.0})()
         ({increasingRate = 0.3})()
         ({startAngle = 45})()
         ({sparkleAmount = 1.0})()


### PR DESCRIPTION
1. Remove noiseInfluence
2. Use noiseThreshold for binary threshold
3. Reduce the enhancement ratio

Reference: https://github.com/cardinalblue/CBVisualEffectBuiltins/compare/dev...task/kirakira_light_area_improvement

# Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/cardinalblue/pic-collage-ios/assets/40178645/c1ae73da-9f86-4672-8ad8-200a02a83b7e

</td>
<td>

https://github.com/cardinalblue/pic-collage-ios/assets/40178645/a080eda9-5181-4a18-b988-0c7fa89bc1b4

</td>
</tr>
</table>