### PR TITLE
:bug: memory leak from GaussianBlur

### DIFF
--- a/framework/Source/Operations/GaussianBlur.swift
+++ b/framework/Source/Operations/GaussianBlur.swift
@@ -20,16 +20,16 @@ public class GaussianBlur: BasicOperation {
         self.useMetalPerformanceShaders = true
         
         ({blurRadiusInPixels = 2.0})()
-        
         if #available(iOS 9, macOS 10.13, *) {
-            self.metalPerformanceShaderPathway = usingMPSImageGaussianBlur
+            self.metalPerformanceShaderPathway = { [weak self] commandBuffer, inputTextures, outputTexture in
+                (self?.internalMPSImageGaussianBlur as? MPSImageGaussianBlur)?.encode(
+                    commandBuffer:commandBuffer,
+                    sourceTexture:inputTextures[0]!.texture,
+                    destinationTexture:outputTexture.texture
+                )
+            }
         } else {
             fatalError("Gaussian blur not yet implemented on pre-MPS OS versions")
         }
     }
-    
-    @available(iOS 9, macOS 10.13, *) func usingMPSImageGaussianBlur(commandBuffer:MTLCommandBuffer, inputTextures:[UInt:Texture], outputTexture:Texture) {
-        (internalMPSImageGaussianBlur as? MPSImageGaussianBlur)?.encode(commandBuffer:commandBuffer, sourceTexture:inputTextures[0]!.texture, destinationTexture:outputTexture.texture)
-    }
-    
 }


### PR DESCRIPTION
### Descriptions:
- The author of `GPUImage3` used an inrequired way to implement the `GaussianBlur`, which caused the memory leak to occur.
- Remove the `usingMPSImageGaussianBlur` and set up the `metalPerformanceShaderPathway` directly

### Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/cardinalblue/GPUImage3/assets/40178645/4ddd04a9-2238-4fe4-ae2c-3d7f9dabcf4b

</td>
<td>

https://github.com/cardinalblue/GPUImage3/assets/40178645/8512bdaf-f4f8-4d44-815c-663871be7ae0

</td>
</tr>
</table>