### PR TITLE
feat: async process image for structured concurrency environment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "GPUImage",
     platforms: [
-        .macOS(.v10_11), .iOS(.v9),
+        .macOS(.v10_11), .iOS(.v13),
     ],
     products: [
         .library(

--- a/framework/Source/PictureInput.swift
+++ b/framework/Source/PictureInput.swift
@@ -85,7 +85,6 @@ public class PictureInput: ImageSource {
         }
     }
 
-    @available(iOS 13, *)
     public func processImage() async {
         if let texture = internalTexture {
             updateTargetsWithTexture(texture)

--- a/framework/Source/PictureInput.swift
+++ b/framework/Source/PictureInput.swift
@@ -97,7 +97,7 @@ public class PictureInput: ImageSource {
         let textureLoader = MTKTextureLoader(device: sharedMetalRenderingDevice.device)
         do {
             let mtlTexture = try await textureLoader.newTexture(
-                cgImage:internalImage,
+                cgImage: internalImage,
                 options: newTextureOptions
             )
             self.internalImage = nil
@@ -105,8 +105,9 @@ public class PictureInput: ImageSource {
             let texture = makeTexture(with: mtlTexture)
             internalTexture = texture
             updateTargetsWithTexture(texture)
+            hasProcessedImage = true
         } catch {
-            assertionFailure("Failed loading image texture")
+            assertionFailure("Failed loading image texture: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Descriptions:

- This PR implement a async version of `processImage()` for the Structured Concurrency environment.
- There's a chance to lock the executing thread due to newTexture by calling the original processImage under the Structured Concurrency environment.
- For more details, see: [我語你 await-newTexture](https://www.notion.so/piccollage/await-newTexture-3962c12cc694452faeaa8210760898f4)