### PR TITLE
fix: kirakira result improvement #86epjek7n

### DIFF
--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -38,7 +38,7 @@ public class Kirakira: OperationGroup {
         public var targetDimension: Int
 
         public init(
-            blendRatio: Float = 0.7,
+            blendRatio: Float = 0.5,
             colorMode: ColorMode = .random,
             saturation: Float = 0.5,
             centerSaturation: Float = 0.3,
@@ -85,7 +85,7 @@ public class Kirakira: OperationGroup {
     // MARK: Properties
     // For preprocessing
     // 0 ~ 1
-    var blendRatio: Float = 0.7 {
+    var blendRatio: Float = 0.5 {
         didSet { alphaBlend.mix = blendRatio }
     }
 

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -52,7 +52,7 @@ public class Kirakira: OperationGroup {
             minHue: Float = 0.0,
             maxHue: Float = 1.0,
             increasingRate: Float = 0.03,
-            sparkleAmount: Float = 1.0,
+            sparkleAmount: Float = 0.6,
             frameRate: Float = 60,
             blur: Int = 0,
             targetDimension: Int = 1024
@@ -117,7 +117,7 @@ public class Kirakira: OperationGroup {
         didSet { sparklesEffect.equalBrightness = equalBrightness }
     }
     // 0 - 10
-    public var speed: Float = 7.5 {
+    public var speed: Float = 0 {
         didSet { sparklesEffect.speed = speed }
     }
     // 1 - 5
@@ -142,7 +142,7 @@ public class Kirakira: OperationGroup {
     public var increasingRate: Float = 0.3 {
         didSet { sparklesEffect.increasingRate = increasingRate }
     }
-    public var sparkleAmount: Float = 1.0 {
+    public var sparkleAmount: Float = 0.6 {
         didSet { sparklesEffect.sparkleAmount = sparkleAmount}
     }
     // 1 - 120
@@ -165,7 +165,6 @@ public class Kirakira: OperationGroup {
     private let blendImageRescaleEffect = CBRescaleEffect()
     private let histogramEqualization = HistogramEqualization()
     private let alphaBlend = AlphaBlend()
-    private let brightnessEffect = BrightnessAdjustment()
     private let preprocessSaturationEffect = SaturationAdjustment()
     private let preprocessBlurEffect = GaussianBlur()
 
@@ -218,15 +217,14 @@ public class Kirakira: OperationGroup {
             --> blendImageRescaleEffect
             --> preprocessSaturationEffect
             --> preprocessBlurEffect
+
+            preprocessBlurEffect
             --> histogramEqualization
             histogramEqualization.addTarget(alphaBlend, atTargetIndex: 1)
 
             preprocessBlurEffect
             --> alphaBlend
-            --> brightnessEffect
             --> sparklesEffect
-
-            sparklesEffect
             --> blurEffect
             --> saturationEffect
             saturationEffect.addTarget(addBlend, atTargetIndex: 1)

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -218,7 +218,8 @@ public class Kirakira: OperationGroup {
             --> blendImageRescaleEffect
             --> preprocessSaturationEffect
             --> preprocessBlurEffect
-            preprocessBlurEffect.addTarget(addBlend, atTargetIndex: 1)
+            --> histogramEqualization
+            histogramEqualization.addTarget(alphaBlend, atTargetIndex: 1)
 
             preprocessBlurEffect
             --> alphaBlend

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -154,10 +154,7 @@ public class Kirakira: OperationGroup {
     }
     // For the blur effect
     public var blur: Int = 0 {
-        didSet {
-            blurEffect.blurRadiusInPixels = Float(blur)
-            preprocessBlurEffect.blurRadiusInPixels = Float(blur)
-        }
+        didSet { blurEffect.blurRadiusInPixels = Float(blur) }
     }
 
     // MARK: Effects
@@ -211,18 +208,19 @@ public class Kirakira: OperationGroup {
             blur = parameters.blur
         })()
         preprocessSaturationEffect.saturation = 0
+        preprocessBlurEffect.blurRadiusInPixels = 5.0
 
         self.configureGroup { input, output in
             input
             --> blendImageRescaleEffect
             --> preprocessSaturationEffect
-            --> preprocessBlurEffect
 
-            preprocessBlurEffect
+            preprocessSaturationEffect
+            --> preprocessBlurEffect
             --> histogramEqualization
             histogramEqualization.addTarget(alphaBlend, atTargetIndex: 1)
 
-            preprocessBlurEffect
+            preprocessSaturationEffect
             --> alphaBlend
             --> sparklesEffect
             --> blurEffect

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -157,7 +157,10 @@ public class Kirakira: OperationGroup {
     }
     // For the blur effect
     public var blur: Int = 0 {
-        didSet { blurEffect.blurRadiusInPixels = Float(blur) }
+        didSet {
+            blurEffect.blurRadiusInPixels = Float(blur)
+            preprocessBlurEffect.blurRadiusInPixels = Float(blur)
+        }
     }
 
     // MARK: Effects
@@ -166,6 +169,8 @@ public class Kirakira: OperationGroup {
     private let histogramEqualization = HistogramEqualization()
     private let alphaBlend = AlphaBlend()
     private let brightnessEffect = BrightnessAdjustment()
+    private let preprocessSaturationEffect = SaturationAdjustment()
+    private let preprocessBlurEffect = GaussianBlur()
 
     private let sparklesEffect: Sparkles
     private let blurEffect = GaussianBlur()
@@ -209,13 +214,16 @@ public class Kirakira: OperationGroup {
             frameRate = parameters.frameRate
             blur = parameters.blur
         })()
+        preprocessSaturationEffect.saturation = 0
 
         self.configureGroup { input, output in
             input
             --> blendImageRescaleEffect
-            blendImageRescaleEffect.addTarget(addBlend, atTargetIndex: 1)
+            --> preprocessSaturationEffect
+            --> preprocessBlurEffect
+            preprocessBlurEffect.addTarget(addBlend, atTargetIndex: 1)
 
-            blendImageRescaleEffect
+            preprocessBlurEffect
             --> alphaBlend
             --> brightnessEffect
             --> sparklesEffect

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -117,7 +117,7 @@ public class Kirakira: OperationGroup {
         didSet { sparklesEffect.equalBrightness = equalBrightness }
     }
     // 0 - 10
-    public var speed: Float = 0 {
+    public var speed: Float = 7.5 {
         didSet { sparklesEffect.speed = speed }
     }
     // 1 - 5

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -217,7 +217,7 @@ public class Kirakira: OperationGroup {
             --> blendImageRescaleEffect
             blendImageRescaleEffect.addTarget(addBlend, atTargetIndex: 1)
 
-            input
+            blendImageRescaleEffect
             --> alphaBlend
             --> brightnessEffect
             --> sparklesEffect

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -83,7 +83,6 @@ public class Kirakira: OperationGroup {
     }
 
     // MARK: Properties
-    // For preprocessing
     // 0 ~ 1
     var blendRatio: Float = 0.5 {
         didSet { alphaBlend.mix = blendRatio }
@@ -187,7 +186,6 @@ public class Kirakira: OperationGroup {
     public init(with parameters: Parameters) {
         self.rayCount = parameters.rayCount
         self.sparklesEffect = Sparkles(rayCount: parameters.rayCount)
-        self.preprocessing = parameters.preprocessing
         super.init()
 
         ({
@@ -256,6 +254,7 @@ public extension Kirakira.Parameters {
 extension Kirakira.Parameters: Decodable {
 
     fileprivate enum CodingKeys: String, CodingKey {
+        case blendRatio
         case equalMinHue
         case equalMaxHue
         case equalSaturation
@@ -270,7 +269,6 @@ extension Kirakira.Parameters: Decodable {
         case centerSaturation
         case minHue
         case maxHue
-        case noiseInfluence
         case increasingRate
         case startAngle
         case sparkleAmount
@@ -280,6 +278,7 @@ extension Kirakira.Parameters: Decodable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        blendRatio = try container.decodeParamValue(Float.self, forKey: .blendRatio)
         equalMinHue = try container.decodeParamValue(Float.self, forKey: .equalMinHue)
         equalMaxHue = try container.decodeParamValue(Float.self, forKey: .equalMaxHue)
         equalSaturation = try container.decodeParamValue(Float.self, forKey: .equalSaturation)

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -16,7 +16,6 @@ public class Kirakira: OperationGroup {
     }
 
     public struct Parameters {
-        public var blendRatio: Float
         public var colorMode: ColorMode
         public var saturation: Float
         public var centerSaturation: Float
@@ -38,7 +37,6 @@ public class Kirakira: OperationGroup {
         public var targetDimension: Int
 
         public init(
-            blendRatio: Float = 0.5,
             colorMode: ColorMode = .random,
             saturation: Float = 0.5,
             centerSaturation: Float = 0.3,
@@ -59,7 +57,6 @@ public class Kirakira: OperationGroup {
             blur: Int = 0,
             targetDimension: Int = 1024
         ) {
-            self.blendRatio = blendRatio
             self.colorMode = colorMode
             self.saturation = saturation
             self.centerSaturation = centerSaturation
@@ -194,7 +191,7 @@ public class Kirakira: OperationGroup {
         super.init()
 
         ({
-            blendRatio = parameters.blendRatio
+            blendRatio = 0.5
             colorMode = parameters.colorMode
             targetDimension = parameters.targetDimension
             saturation = parameters.saturation
@@ -262,7 +259,6 @@ public extension Kirakira.Parameters {
 extension Kirakira.Parameters: Decodable {
 
     fileprivate enum CodingKeys: String, CodingKey {
-        case blendRatio
         case equalMinHue
         case equalMaxHue
         case equalSaturation
@@ -286,7 +282,6 @@ extension Kirakira.Parameters: Decodable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        blendRatio = try container.decodeParamValue(Float.self, forKey: .blendRatio)
         equalMinHue = try container.decodeParamValue(Float.self, forKey: .equalMinHue)
         equalMaxHue = try container.decodeParamValue(Float.self, forKey: .equalMaxHue)
         equalSaturation = try container.decodeParamValue(Float.self, forKey: .equalSaturation)

--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -16,7 +16,6 @@ public class Kirakira: OperationGroup {
     }
 
     public struct Parameters {
-        public var preprocessing: Bool
         public var blendRatio: Float
         public var colorMode: ColorMode
         public var saturation: Float
@@ -39,7 +38,6 @@ public class Kirakira: OperationGroup {
         public var targetDimension: Int
 
         public init(
-            preprocessing: Bool = true,
             blendRatio: Float = 0.7,
             colorMode: ColorMode = .random,
             saturation: Float = 0.5,
@@ -61,7 +59,6 @@ public class Kirakira: OperationGroup {
             blur: Int = 0,
             targetDimension: Int = 1024
         ) {
-            self.preprocessing = preprocessing
             self.blendRatio = blendRatio
             self.colorMode = colorMode
             self.saturation = saturation
@@ -87,7 +84,6 @@ public class Kirakira: OperationGroup {
 
     // MARK: Properties
     // For preprocessing
-    let preprocessing: Bool
     // 0 ~ 1
     var blendRatio: Float = 0.7 {
         didSet { alphaBlend.mix = blendRatio }
@@ -217,20 +213,14 @@ public class Kirakira: OperationGroup {
         })()
 
         self.configureGroup { input, output in
-            if preprocessing {
-                input
-                --> blendImageRescaleEffect
-                blendImageRescaleEffect.addTarget(addBlend, atTargetIndex: 1)
+            input
+            --> blendImageRescaleEffect
+            blendImageRescaleEffect.addTarget(addBlend, atTargetIndex: 1)
 
-                input
-                --> alphaBlend
-                --> brightnessEffect
-                --> sparklesEffect
-            } else {
-                input
-                --> blendImageRescaleEffect
-                --> sparklesEffect
-            }
+            input
+            --> alphaBlend
+            --> brightnessEffect
+            --> sparklesEffect
 
             sparklesEffect
             --> blurEffect

--- a/framework/Source/Operations/CBKirakiraLightExtractor.metal
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.metal
@@ -37,20 +37,20 @@ fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput
 
     float3 luminanceFactor = float3(0.2126, 0.7152, 0.0722); // RGB to Y
 
-    float widthStep = 10.0 / inputTexture.get_width();
-    float heightStep = 10.0 / inputTexture.get_height();
+    float widthStep = 15.0 / inputTexture.get_width();
+    float heightStep = 15.0 / inputTexture.get_height();
 
     // uv for all 8 directions
-    float2 uv_left = uv + float2(-widthStep, 0.0);
-    float2 uv_right = uv + float2(widthStep, 0.0);
+    float2 uv_left = clamp(uv + float2(-widthStep, 0.0), 0.0, 1.0);
+    float2 uv_right = clamp(uv + float2(widthStep, 0.0), 0.0, 1.0);
 
-    float2 uv_top = uv + float2(0.0, -heightStep);
-    float2 uv_topLeft = uv + float2(-widthStep, -heightStep);
-    float2 uv_topRight = uv + float2(widthStep, -heightStep);
+    float2 uv_top = clamp(uv + float2(0.0, -heightStep), 0.0, 1.0);
+    float2 uv_topLeft = clamp(uv + float2(-widthStep, -heightStep), 0.0, 1.0);
+    float2 uv_topRight = clamp(uv + float2(widthStep, -heightStep), 0.0, 1.0);
 
-    float2 uv_bottom = uv + float2(0.0, heightStep);
-    float2 uv_bottomLeft = uv + float2(-widthStep, heightStep);
-    float2 uv_bottomRight = uv + float2(widthStep, heightStep);
+    float2 uv_bottom = clamp(uv + float2(0.0, heightStep), 0.0, 1.0);
+    float2 uv_bottomLeft = clamp(uv + float2(-widthStep, heightStep), 0.0, 1.0);
+    float2 uv_bottomRight = clamp(uv + float2(widthStep, heightStep), 0.0, 1.0);
 
     // luminance for 9 positions
     float luminance = dot(inputTexture.sample(quadSampler, uv).rgb, luminanceFactor);
@@ -81,7 +81,8 @@ fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput
     outputValue = count > 3.0 ? luminance : 0.0;
 
     // Apply threshold on noise texture
-    noiseColor.r = noiseColor.r < uniform.noiseThreshold ? 0.0 : 1.0;
+    float noiseEnhanceRatio = clamp((count / 8.0) * 0.7 + 0.5, 0.0, 1.0);
+    noiseColor.r = noiseColor.r < uniform.noiseThreshold ? 0.0 : mix(uniform.noiseThreshold, 1.0, noiseEnhanceRatio);
 
     // Increase the appearance probability of the bright area
     float increaseValue = luminance > (uniform.luminanceThreshold) * 1.1 ? ((rand(uv) - (1.0 - uniform.increasingRate)) * 0.5) : 0.0;

--- a/framework/Source/Operations/CBKirakiraLightExtractor.metal
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.metal
@@ -75,10 +75,9 @@ fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput
     if (luminance_bottomLeft + uniform.gapThreshold < luminance) count += 1.0;
     if (luminance_bottomRight + uniform.gapThreshold < luminance) count += 1.0;
 
-    // Two ways: 1. if the center is brighter than the luminanceThreshold, then the output is bright
-    //           2. lighter than 4 directions, then the output is bright
+    // The center is brighter than the threshold, then the output is bright
     float outputValue = luminance > uniform.luminanceThreshold ? 1.0 : 0.0;
-    if (count > 4.0) outputValue = luminance;
+    // If the center is not brighter than its neighbors, then the output is dark (prevent from the whole area is bright)
     outputValue = count > 3.0 ? luminance : 0.0;
 
     // Apply threshold on noise texture

--- a/framework/Source/Operations/CBPerlineNoise.metal
+++ b/framework/Source/Operations/CBPerlineNoise.metal
@@ -112,7 +112,7 @@ fragment float4 perlineNoiseFragment(SingleInputVertexIO fragmentInput [[ stage_
     value = 0.2 + 0.8*value;
 
     // Enhance the difference
-    value = pow(value + 0.5, 1.5) - 0.5;
+    value = (pow(value + 0.5, 1.3) - 0.5) * 1.3;
 
     return float4(float3(value), inputColor.a);
 }

--- a/framework/Source/Operations/CBPerlineNoise.metal
+++ b/framework/Source/Operations/CBPerlineNoise.metal
@@ -109,10 +109,10 @@ fragment float4 perlineNoiseFragment(SingleInputVertexIO fragmentInput [[ stage_
     value = simplex3d_fractal(p3*8.0+8.0);
 
     // The greater the weight(0.8), the greater the difference between light and dark.
-    value = 0.2 + 0.8*value;
+    value = 0.1 + 0.9*value;
 
     // Enhance the difference
-    value = (pow(value + 0.5, 1.3) - 0.5) * 1.3;
+    value = (pow(value + 0.5, 1.3) - 0.5) * 1.4;
 
     return float4(float3(value), inputColor.a);
 }

--- a/framework/Source/Operations/CBPerlineNoise.metal
+++ b/framework/Source/Operations/CBPerlineNoise.metal
@@ -108,7 +108,7 @@ fragment float4 perlineNoiseFragment(SingleInputVertexIO fragmentInput [[ stage_
 
     value = simplex3d_fractal(p3*8.0+8.0);
 
-    // The greater the weight(0.8), the greater the difference between light and dark.
+    // The greater the weight(0.9), the greater the difference between light and dark.
     value = 0.1 + 0.9*value;
 
     // Enhance the difference

--- a/framework/Source/Operations/CBPerlineNoise.swift
+++ b/framework/Source/Operations/CBPerlineNoise.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class CBPerlineNoise: BasicOperation {
     // 0.1 ~ 10.0
-    public var scale: Float = 0.5 { didSet { uniformSettings["scale"] = scale } }
+    public var scale: Float = 0.5 { didSet { uniformSettings["scale"] = 1 / scale } }
     // 0 ~ 10.0
     public var speed: Float = 1.0 { didSet { updateTime() } }
     // 1 ~ 120

--- a/framework/Source/Operations/CBPerlineNoise.swift
+++ b/framework/Source/Operations/CBPerlineNoise.swift
@@ -25,7 +25,7 @@ public class CBPerlineNoise: BasicOperation {
     public init() {
         super.init(fragmentFunctionName:"perlineNoiseFragment", numberOfInputs: 1)
         ({
-            scale = 0.7
+            scale = 0.5
             updateTime()
         })()
     }

--- a/framework/Source/Operations/CBPerlineNoise.swift
+++ b/framework/Source/Operations/CBPerlineNoise.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class CBPerlineNoise: BasicOperation {
     // 0.1 ~ 10.0
-    public var scale: Float = 0.5 { didSet { uniformSettings["scale"] = 1 / scale } }
+    public var scale: Float = 0.6 { didSet { uniformSettings["scale"] = 1 / scale } }
     // 0 ~ 10.0
     public var speed: Float = 1.0 { didSet { updateTime() } }
     // 1 ~ 120
@@ -25,7 +25,7 @@ public class CBPerlineNoise: BasicOperation {
     public init() {
         super.init(fragmentFunctionName:"perlineNoiseFragment", numberOfInputs: 1)
         ({
-            scale = 0.5
+            scale = 0.6
             updateTime()
         })()
     }

--- a/framework/Source/Operations/CBPerlineNoise.swift
+++ b/framework/Source/Operations/CBPerlineNoise.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class CBPerlineNoise: BasicOperation {
     // 0.1 ~ 10.0
-    public var scale: Float = 0.6 { didSet { uniformSettings["scale"] = 1 / scale } }
+    public var scale: Float = 0.4 { didSet { uniformSettings["scale"] = 1 / scale } }
     // 0 ~ 10.0
     public var speed: Float = 1.0 { didSet { updateTime() } }
     // 1 ~ 120
@@ -25,7 +25,7 @@ public class CBPerlineNoise: BasicOperation {
     public init() {
         super.init(fragmentFunctionName:"perlineNoiseFragment", numberOfInputs: 1)
         ({
-            scale = 0.6
+            scale = 0.4
             updateTime()
         })()
     }

--- a/framework/Source/Operations/HistogramEqualization.swift
+++ b/framework/Source/Operations/HistogramEqualization.swift
@@ -9,22 +9,7 @@ import Foundation
 
 public class HistogramEqualization: BasicOperation {
 
-    public enum ConvenientParameterKey: String {
-        case none
-    }
-
-    public let identifier = UUID().uuidString
-
-    public static let name = "HistogramEqualization"
-
-    public static var convenientParameterDefinition: OrderedDictionary<ConvenientParameterKey, VisualEffectParameterDefinition> = [:]
-
-    private var renderer: HistogramEqualizationRenderer
-
-    public required init(convenientParameters: [ConvenientParameterKey : VisualEffectParameterValue]?) {
-        renderer = HistogramEqualizationRenderer()
-        self.convenientParameters = convenientParameters ?? [:]
-    }
+    private var renderer = HistogramEqualizationRenderer()
 
     public override func newTextureAvailable(_ texture: Texture, fromSourceIndex: UInt) {
         guard fromSourceIndex == 0 else {

--- a/framework/Source/Operations/HistogramEqualization.swift
+++ b/framework/Source/Operations/HistogramEqualization.swift
@@ -9,7 +9,12 @@ import Foundation
 
 public class HistogramEqualization: BasicOperation {
 
-    private var renderer = HistogramEqualizationRenderer()
+    private var renderer: HistogramEqualizationRenderer
+
+    init(renderer: HistogramEqualizationRenderer = HistogramEqualizationRenderer()) {
+        self.renderer = renderer
+        super.init(fragmentFunctionName: "")
+    }
 
     public override func newTextureAvailable(_ texture: Texture, fromSourceIndex: UInt) {
         guard fromSourceIndex == 0 else {
@@ -25,7 +30,7 @@ public class HistogramEqualization: BasicOperation {
             textureInputSemaphore.signal()
         }
 
-        frameTexture = texture.texture
+        let frameTexture = texture.texture
         let size = CGSize(
             width: CGFloat(frameTexture.width),
             height: CGFloat(frameTexture.height)

--- a/framework/Source/Operations/HistogramEqualization.swift
+++ b/framework/Source/Operations/HistogramEqualization.swift
@@ -1,0 +1,66 @@
+//
+//  HistogramEqualization.swift
+//
+//
+//  Created by Chiaote Ni on 2024/6/4.
+//
+
+import Foundation
+
+public class HistogramEqualization: BasicOperation {
+
+    public enum ConvenientParameterKey: String {
+        case none
+    }
+
+    public let identifier = UUID().uuidString
+
+    public static let name = "HistogramEqualization"
+
+    public static var convenientParameterDefinition: OrderedDictionary<ConvenientParameterKey, VisualEffectParameterDefinition> = [:]
+
+    private var renderer: HistogramEqualizationRenderer
+
+    public required init(convenientParameters: [ConvenientParameterKey : VisualEffectParameterValue]?) {
+        renderer = HistogramEqualizationRenderer()
+        self.convenientParameters = convenientParameters ?? [:]
+    }
+
+    public override func newTextureAvailable(_ texture: Texture, fromSourceIndex: UInt) {
+        guard fromSourceIndex == 0 else {
+            assertionFailure("sourceIndex out of range")
+            return
+        }
+        guard let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer() else {
+            return
+        }
+
+        let _ = textureInputSemaphore.wait(timeout:DispatchTime.distantFuture)
+        defer {
+            textureInputSemaphore.signal()
+        }
+
+        frameTexture = texture.texture
+        let size = CGSize(
+            width: CGFloat(frameTexture.width),
+            height: CGFloat(frameTexture.height)
+        )
+        let outputTexture = Texture(
+            device: sharedMetalRenderingDevice.device,
+            orientation: texture.orientation,
+            pixelFormat: texture.texture.pixelFormat,
+            width: Int(size.width),
+            height: Int(size.height),
+            timingStyle: texture.timingStyle
+        )
+        inputTextures[0] = texture
+
+        renderer.render(
+            inputFrameBuffer: [frameTexture],
+            outputFrameBuffer: outputTexture.texture
+        )
+
+        removeTransientInputs()
+        updateTargetsWithTexture(outputTexture)
+    }
+}

--- a/framework/Source/Operations/HistogramEqualization.swift
+++ b/framework/Source/Operations/HistogramEqualization.swift
@@ -12,14 +12,10 @@ public class HistogramEqualization: ImageProcessingOperation {
     public let targets = TargetContainer()
     public let sources = SourceContainer()
 
-    private var renderer: HistogramEqualizationRenderer
-    private let textureInputSemaphore = DispatchSemaphore(value:1)
+    private var renderer = HistogramEqualizationRenderer()
+    private let textureInputSemaphore = DispatchSemaphore(value: 1)
 
-    var inputTextures = [UInt: Texture]()
-
-    init(renderer: HistogramEqualizationRenderer = HistogramEqualizationRenderer()) {
-        self.renderer = renderer
-    }
+    private var inputTexture: Texture?
 
     public func transmitPreviousImage(to target: any ImageConsumer, atIndex: UInt) {}
 
@@ -47,22 +43,14 @@ public class HistogramEqualization: ImageProcessingOperation {
             height: Int(size.height),
             timingStyle: texture.timingStyle
         )
-        inputTextures[0] = texture
 
+        inputTexture = texture
         renderer.render(
             inputFrameBuffer: [frameTexture],
             outputFrameBuffer: outputTexture.texture
         )
+        inputTexture = nil
 
-        removeTransientInputs()
         updateTargetsWithTexture(outputTexture)
-    }
-
-    private func removeTransientInputs() {
-        for index in 0 ..< self.maximumInputs {
-            if let texture = inputTextures[index], texture.timingStyle.isTransient() {
-                inputTextures[index] = nil
-            }
-        }
     }
 }

--- a/framework/Source/Operations/HistogramEqualizationRenderer.swift
+++ b/framework/Source/Operations/HistogramEqualizationRenderer.swift
@@ -51,40 +51,4 @@ class HistogramEqualizationRenderer: MetalRenderer {
         commandBuffer.commit()
         commandBuffer.waitUntilCompleted()
     }
-    
-    override func render(
-        inputFrameBuffer: [MTLTexture],
-        outputFrameBuffer: MTLTexture?,
-        commandBuffer: MTLCommandBuffer,
-        parameters: Any? = nil
-    ) {
-        guard let targetTexture = outputFrameBuffer,
-              let inputTexture = inputFrameBuffer.first
-        else { return }
-        
-        guard let device = self.metalDevice
-        else { return }
-        
-        var histogramInfo = MPSImageHistogramInfo(
-            numberOfHistogramEntries: 256,
-            histogramForAlpha: false,
-            minPixelValue: vector_float4(0,0,0,0),
-            maxPixelValue: vector_float4(1,1,1,1))
-             
-        let calculation = MPSImageHistogram(device: device,
-                                            histogramInfo: &histogramInfo)
-        let bufferLength = calculation.histogramSize(forSourceFormat: inputTexture.pixelFormat)
-        guard let histogramInfoBuffer = device.makeBuffer(length: bufferLength, options: [.storageModePrivate])
-        else { return }
-             
-        calculation.encode(to: commandBuffer,
-                           sourceTexture: inputTexture,
-                           histogram: histogramInfoBuffer,
-                           histogramOffset: 0)
-        
-        let equalization = MPSImageHistogramEqualization(device: device, histogramInfo: &histogramInfo)
-        equalization.encodeTransform(to: commandBuffer, sourceTexture: inputTexture, histogram: histogramInfoBuffer, histogramOffset: 0)
-        equalization.encode(commandBuffer: commandBuffer, sourceTexture: inputTexture, destinationTexture: targetTexture)
-    }
-    
 }

--- a/framework/Source/Operations/HistogramEqualizationRenderer.swift
+++ b/framework/Source/Operations/HistogramEqualizationRenderer.swift
@@ -1,0 +1,90 @@
+//
+//  HistogramEqualizationRenderer.swift
+//  CBVisualEffectBuiltins
+//
+//  Created by Vivienne Ko on 2024/5/29.
+//
+
+import Metal
+import Foundation
+import MetalPerformanceShaders
+
+class HistogramEqualizationRenderer: MetalRenderer {
+    
+    override func render(
+        inputFrameBuffer: [MTLTexture],
+        outputFrameBuffer: MTLTexture?,
+        parameters: Any? = nil
+    ) {
+        guard let targetTexture = outputFrameBuffer,
+              let inputTexture = inputFrameBuffer.first
+        else { return }
+        
+        guard let commandQueue,
+              let commandBuffer = commandQueue.makeCommandBuffer()
+        else { return }
+        
+        guard let device = self.metalDevice
+        else { return }
+        
+        var histogramInfo = MPSImageHistogramInfo(
+            numberOfHistogramEntries: 256,
+            histogramForAlpha: false,
+            minPixelValue: vector_float4(0,0,0,0),
+            maxPixelValue: vector_float4(1,1,1,1))
+             
+        let calculation = MPSImageHistogram(device: device,
+                                            histogramInfo: &histogramInfo)
+        let bufferLength = calculation.histogramSize(forSourceFormat: inputTexture.pixelFormat)
+        guard let histogramInfoBuffer = device.makeBuffer(length: bufferLength, options: [.storageModePrivate])
+        else { return }
+             
+        calculation.encode(to: commandBuffer,
+                           sourceTexture: inputTexture,
+                           histogram: histogramInfoBuffer,
+                           histogramOffset: 0)
+        
+        let equalization = MPSImageHistogramEqualization(device: device, histogramInfo: &histogramInfo)
+        equalization.encodeTransform(to: commandBuffer, sourceTexture: inputTexture, histogram: histogramInfoBuffer, histogramOffset: 0)
+        equalization.encode(commandBuffer: commandBuffer, sourceTexture: inputTexture, destinationTexture: targetTexture)
+        
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+    }
+    
+    override func render(
+        inputFrameBuffer: [MTLTexture],
+        outputFrameBuffer: MTLTexture?,
+        commandBuffer: MTLCommandBuffer,
+        parameters: Any? = nil
+    ) {
+        guard let targetTexture = outputFrameBuffer,
+              let inputTexture = inputFrameBuffer.first
+        else { return }
+        
+        guard let device = self.metalDevice
+        else { return }
+        
+        var histogramInfo = MPSImageHistogramInfo(
+            numberOfHistogramEntries: 256,
+            histogramForAlpha: false,
+            minPixelValue: vector_float4(0,0,0,0),
+            maxPixelValue: vector_float4(1,1,1,1))
+             
+        let calculation = MPSImageHistogram(device: device,
+                                            histogramInfo: &histogramInfo)
+        let bufferLength = calculation.histogramSize(forSourceFormat: inputTexture.pixelFormat)
+        guard let histogramInfoBuffer = device.makeBuffer(length: bufferLength, options: [.storageModePrivate])
+        else { return }
+             
+        calculation.encode(to: commandBuffer,
+                           sourceTexture: inputTexture,
+                           histogram: histogramInfoBuffer,
+                           histogramOffset: 0)
+        
+        let equalization = MPSImageHistogramEqualization(device: device, histogramInfo: &histogramInfo)
+        equalization.encodeTransform(to: commandBuffer, sourceTexture: inputTexture, histogram: histogramInfoBuffer, histogramOffset: 0)
+        equalization.encode(commandBuffer: commandBuffer, sourceTexture: inputTexture, destinationTexture: targetTexture)
+    }
+    
+}

--- a/framework/Source/Sparkles.swift
+++ b/framework/Source/Sparkles.swift
@@ -52,7 +52,7 @@ public class Sparkles: OperationGroup {
     public var sparkleAmount: Float = 1.0 {
         didSet {
             lightExtractorEffect.luminanceThreshold = 1.0 - sparkleAmount * 0.5
-            lightExtractorEffect.noiseThreshold = sparkleAmount == 0.0 ? 1.0 : 0.2 * (1.0 - sparkleAmount) + 0.3
+            lightExtractorEffect.noiseThreshold = sparkleAmount == 0.0 ? 1.0 : 0.2 * (1.0 - sparkleAmount) + 0.32
         }
     }
     // DirectionalBlurs


### PR DESCRIPTION
# Context
- There are times that it shows either too many sparkles or no sparkles when applying sparkle overlay. 
- We identified that's due to the brightness/contrast distribution of the photo. 
- To improve the result, we will first do some normalization before generating sparkles.

# Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![IMG_9980](https://github.com/cardinalblue/GPUImage3/assets/40178645/1491aa0f-05c0-42c2-8b35-9d27eb6877ed)

</td>
<td>

![IMG_9979](https://github.com/cardinalblue/GPUImage3/assets/40178645/c002df0d-f9cc-474f-a7e8-6294396ad512)

</td>
</tr>
</table>