### PR TITLE
feat: face mask for kirakira effect #86epjek8p

### DIFF
--- a/framework/Source/Kirakira.swift
+++ b/framework/Source/Kirakira.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2024 Red Queen Coder, LLC. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 public class Kirakira: OperationGroup {
 
@@ -102,6 +102,9 @@ public class Kirakira: OperationGroup {
     // For sparkles effect
     public var centerSaturation: Float = 0.3 {
         didSet { updateSparkleSaturation() }
+    }
+    public var faceMaskImage: UIImage? {
+        didSet { sparklesEffect.faceMaskImage = faceMaskImage }
     }
     public var equalMinHue: Float = 0.54 {
         didSet { sparklesEffect.equalMinHue = equalMinHue }

--- a/framework/Source/Operations/CBAddBlend.swift
+++ b/framework/Source/Operations/CBAddBlend.swift
@@ -52,6 +52,6 @@ public class CBAddBlend: BasicOperation {
             super.newTextureAvailable(texture, fromSourceIndex: fromSourceIndex)
             lock.signal()
         }
-        lock.wait(timeout: .now() + 2)
+        _ = lock.wait(timeout: .now() + 2)
     }
 }

--- a/framework/Source/Operations/CBKirakiraLightExtractor.metal
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.metal
@@ -37,7 +37,6 @@ fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput
     float4 inputColor = inputTexture.sample(quadSampler, uv);
     float4 noiseColor = noiseTexture.sample(quadSampler, uv); // to block out some area
     float4 voidMaskColor = voidMaskTexture.sample(quadSampler, uv);
-    float applyVoidMask;
 
     float3 luminanceFactor = float3(0.2126, 0.7152, 0.0722); // RGB to Y
 

--- a/framework/Source/Operations/CBKirakiraLightExtractor.metal
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.metal
@@ -22,11 +22,13 @@ struct LightExtractorUniform {
     float equalMaxHue;
     float equalSaturation;
     float equalBrightness;
+    float applyVoidMask;
 };
 
 fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput [[stage_in]],
                                                texture2d<float> inputTexture [[texture(0)]],
                                                texture2d<float> noiseTexture [[texture(1)]],
+                                               texture2d<float> voidMaskTexture [[texture(2)]],
                                                constant LightExtractorUniform& uniform [[ buffer(1) ]])
 {
     constexpr sampler quadSampler;
@@ -34,6 +36,8 @@ fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput
     float2 uv = fragmentInput.textureCoordinate;
     float4 inputColor = inputTexture.sample(quadSampler, uv);
     float4 noiseColor = noiseTexture.sample(quadSampler, uv); // to block out some area
+    float4 voidMaskColor = voidMaskTexture.sample(quadSampler, uv);
+    float applyVoidMask;
 
     float3 luminanceFactor = float3(0.2126, 0.7152, 0.0722); // RGB to Y
 
@@ -99,6 +103,8 @@ fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput
     float enhanceRatio = step(hue, uniform.equalMinHue) * step(uniform.equalMaxHue, hue) > 0.0 ? 0.0 : 1.0;
     float3 hsv = float3(hue, 1.0 - enhanceRatio * uniform.equalSaturation, min(outputValue * (enhanceRatio * uniform.equalBrightness + 1.0), 1.0));
     float3 outputColor = hsv2rgb(hsv);
+
+    outputColor *= (1.0 - voidMaskColor.a * uniform.applyVoidMask);
 
     return float4(outputColor, inputColor.a);
 }

--- a/framework/Source/Operations/CBKirakiraLightExtractor.metal
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.metal
@@ -22,7 +22,6 @@ struct LightExtractorUniform {
     float equalMaxHue;
     float equalSaturation;
     float equalBrightness;
-    float applyVoidMask;
 };
 
 fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput [[stage_in]],
@@ -103,7 +102,7 @@ fragment float4 kirakiraLightExtractorFragment(SingleInputVertexIO fragmentInput
     float3 hsv = float3(hue, 1.0 - enhanceRatio * uniform.equalSaturation, min(outputValue * (enhanceRatio * uniform.equalBrightness + 1.0), 1.0));
     float3 outputColor = hsv2rgb(hsv);
 
-    outputColor *= (1.0 - voidMaskColor.a * uniform.applyVoidMask);
+    outputColor *= (1.0 - voidMaskColor.a);
 
     return float4(outputColor, inputColor.a);
 }

--- a/framework/Source/Operations/CBKirakiraLightExtractor.swift
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.swift
@@ -9,6 +9,9 @@
 import Foundation
 
 public class CBKirakiraLightExtractor: BasicOperation {
+    public var applyVoidMask: Bool = false {
+        didSet { uniformSettings["applyVoidMask"] = applyVoidMask ? 1.0 : 0.0 }
+    }
     // 0.0 ~ 1.0
     public var luminanceThreshold: Float = 0.8 {
         didSet { uniformSettings["luminanceThreshold"] = luminanceThreshold }
@@ -51,7 +54,7 @@ public class CBKirakiraLightExtractor: BasicOperation {
     }
 
     public init() {
-        super.init(fragmentFunctionName:"kirakiraLightExtractorFragment", numberOfInputs: 2)
+        super.init(fragmentFunctionName:"kirakiraLightExtractorFragment", numberOfInputs: 3)
         ({
             luminanceThreshold = 0.8
             gapThreshold = 0.2
@@ -63,6 +66,7 @@ public class CBKirakiraLightExtractor: BasicOperation {
             equalMaxHue = 0.083
             equalSaturation = 0.15
             equalBrightness = 2.0
+            applyVoidMask = false
         })()
     }
 }

--- a/framework/Source/Operations/CBKirakiraLightExtractor.swift
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.swift
@@ -10,13 +10,6 @@ import Foundation
 
 public class CBKirakiraLightExtractor: BasicOperation {
 
-    override var inputTextures: [UInt: Texture] {
-        didSet { applyVoidMask = inputTextures[2] != nil }
-    }
-
-    private var applyVoidMask: Bool = false {
-        didSet { uniformSettings["applyVoidMask"] = true ? 1.0 : 0.0 }
-    }
     // 0.0 ~ 1.0
     public var luminanceThreshold: Float = 0.8 {
         didSet { uniformSettings["luminanceThreshold"] = luminanceThreshold }
@@ -71,7 +64,6 @@ public class CBKirakiraLightExtractor: BasicOperation {
             equalMaxHue = 0.083
             equalSaturation = 0.15
             equalBrightness = 2.0
-            applyVoidMask = false
         })()
     }
 }

--- a/framework/Source/Operations/CBKirakiraLightExtractor.swift
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.swift
@@ -10,6 +10,16 @@ import Foundation
 
 public class CBKirakiraLightExtractor: BasicOperation {
 
+    public var faceMaskInput: PictureInput? {
+        willSet {
+            inputTextures.removeValue(forKey: 2)
+            faceMaskInput?.removeAllTargets()
+        }
+        didSet {
+            faceMaskInput?.addTarget(self, atTargetIndex: 2)
+        }
+    }
+
     // 0.0 ~ 1.0
     public var luminanceThreshold: Float = 0.8 {
         didSet { uniformSettings["luminanceThreshold"] = luminanceThreshold }
@@ -65,5 +75,27 @@ public class CBKirakiraLightExtractor: BasicOperation {
             equalSaturation = 0.15
             equalBrightness = 2.0
         })()
+    }
+
+    public override func newTextureAvailable(_ texture: Texture, fromSourceIndex: UInt) {
+        if fromSourceIndex == 2 {
+            inputTextures[fromSourceIndex] = texture
+            return
+        }
+
+        guard let faceMaskInput, inputTextures[fromSourceIndex] == nil else {
+            super.newTextureAvailable(texture, fromSourceIndex: fromSourceIndex)
+            return
+        }
+
+        // DispatchSemaphore is Sendable and is a kind of async-safe scoped locking
+        // Using NSLock will cause a warning in Xcode and doesn't work as expected at runtime.
+        let lock = DispatchSemaphore(value: 0)
+        Task {
+            await faceMaskInput.processImage()
+            super.newTextureAvailable(texture, fromSourceIndex: fromSourceIndex)
+            lock.signal()
+        }
+        _ = lock.wait(timeout: .now() + 2)
     }
 }

--- a/framework/Source/Operations/CBKirakiraLightExtractor.swift
+++ b/framework/Source/Operations/CBKirakiraLightExtractor.swift
@@ -9,8 +9,13 @@
 import Foundation
 
 public class CBKirakiraLightExtractor: BasicOperation {
-    public var applyVoidMask: Bool = false {
-        didSet { uniformSettings["applyVoidMask"] = applyVoidMask ? 1.0 : 0.0 }
+
+    override var inputTextures: [UInt: Texture] {
+        didSet { applyVoidMask = inputTextures[2] != nil }
+    }
+
+    private var applyVoidMask: Bool = false {
+        didSet { uniformSettings["applyVoidMask"] = true ? 1.0 : 0.0 }
     }
     // 0.0 ~ 1.0
     public var luminanceThreshold: Float = 0.8 {

--- a/framework/Source/Operations/CBScreenBlend.swift
+++ b/framework/Source/Operations/CBScreenBlend.swift
@@ -54,6 +54,6 @@ public class CBScreenBlend: BasicOperation {
             super.newTextureAvailable(texture, fromSourceIndex: fromSourceIndex)
             lock.signal()
         }
-        lock.wait(timeout: .now() + 2)
+        _ = lock.wait(timeout: .now() + 2)
     }
 }

--- a/framework/Source/Sparkles.swift
+++ b/framework/Source/Sparkles.swift
@@ -210,7 +210,7 @@ extension Sparkles {
         faceMaskInput?.removeAllTargets()
         faceMaskInput = {
             guard let newValue else { return nil }
-            return PictureInput(image: newValue, isTransient: true)
+            return PictureInput(image: newValue)
         }()
         lightExtractorEffect.removeSourceAtIndex(2)
 

--- a/framework/Source/Sparkles.swift
+++ b/framework/Source/Sparkles.swift
@@ -31,7 +31,7 @@ public class Sparkles: OperationGroup {
     public var faceMaskImage: UIImage? {
         didSet {
             guard faceMaskImage != oldValue else { return }
-            let maskImage: UIImage = faceMaskImage ?? .emptyMaskImage
+            let maskImage: UIImage = faceMaskImage ?? .makeEmptyMaskImage()
             faceMaskInput = PictureInput(image: maskImage)
         }
     }
@@ -128,7 +128,7 @@ public class Sparkles: OperationGroup {
         self.addBlendEffects = Array(0...rayCount)
             .map { _ in AddBlend() }
 
-        self.faceMaskInput = PictureInput(image: .emptyMaskImage)
+        self.faceMaskInput = PictureInput(image: .makeEmptyMaskImage())
         super.init()
 
         ({equalMinHue = 0.75})()
@@ -225,12 +225,10 @@ extension Sparkles {
 }
 
 private extension UIImage {
+    static func makeEmptyMaskImage() -> UIImage {
+        let size = CGSize(width: 1, height: 1)
+        let color = UIColor.black
 
-    static var emptyMaskImage: UIImage {
-        UIImage(color: .black, size: CGSize(width: 1, height: 1))
-    }
-
-    convenience init(color: UIColor, size: CGSize) {
         UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
         defer { UIGraphicsEndImageContext() }
 
@@ -238,6 +236,6 @@ private extension UIImage {
         context.setFillColor(color.cgColor)
         context.fill(CGRect(x: 0, y: 0, width: size.width, height: size.height))
 
-        self.init(cgImage: context.makeImage()!)
+        return UIGraphicsGetImageFromCurrentImageContext()!
     }
 }

--- a/framework/Source/Sparkles.swift
+++ b/framework/Source/Sparkles.swift
@@ -37,7 +37,7 @@ public class Sparkles: OperationGroup {
     }
     private var faceMaskInput: PictureInput {
         willSet { faceMaskInput.removeAllTargets() }
-        didSet { handleFaceMaskUpdated(faceMaskInput) }
+        didSet { reconnectFaceMaskInput(faceMaskInput) }
     }
 
     public var equalMinHue: Float = 0.75 {
@@ -160,6 +160,7 @@ public class Sparkles: OperationGroup {
 
         setUpPipeline()
         updateDirectionalShines()
+        reconnectFaceMaskInput(faceMaskInput)
     }
 }
 
@@ -212,7 +213,7 @@ extension Sparkles {
         }
     }
 
-    private func handleFaceMaskUpdated(_ maskInput: PictureInput) {
+    private func reconnectFaceMaskInput(_ maskInput: PictureInput) {
         let semaphore = DispatchSemaphore(value: 0)
 
         maskInput.addTarget(lightExtractorEffect, atTargetIndex: 2)
@@ -227,7 +228,7 @@ extension Sparkles {
 private extension UIImage {
     static func makeEmptyMaskImage() -> UIImage {
         let size = CGSize(width: 1, height: 1)
-        let color = UIColor.black
+        let color = UIColor.clear
 
         UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
         defer { UIGraphicsEndImageContext() }

--- a/framework/Source/Sparkles.swift
+++ b/framework/Source/Sparkles.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2024 Red Queen Coder, LLC. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 public class Sparkles: OperationGroup {
 
@@ -28,6 +28,14 @@ public class Sparkles: OperationGroup {
         didSet { perlinNoiseEffect.time = time }
     }
     // LightExtractor
+    public var faceMaskImage: UIImage? {
+        didSet {
+            guard faceMaskImage != oldValue else { return }
+            handleFaceMaskImageUpdated(from: oldValue, to: faceMaskImage)
+        }
+    }
+    private var faceMaskInput: PictureInput?
+
     public var equalMinHue: Float = 0.75 {
         didSet { lightExtractorEffect.equalMinHue = equalMinHue }
     }
@@ -196,5 +204,18 @@ extension Sparkles {
             node
             --> output
         }
+    }
+
+    private func handleFaceMaskImageUpdated(from oldValue: UIImage?, to newValue: UIImage?) {
+        faceMaskInput?.removeAllTargets()
+        faceMaskInput = {
+            guard let newValue else { return nil }
+            return PictureInput(image: newValue, isTransient: true)
+        }()
+        lightExtractorEffect.removeSourceAtIndex(2)
+
+        guard let faceMaskInput else { return }
+        faceMaskInput.addTarget(lightExtractorEffect, atTargetIndex: 2)
+        faceMaskInput.processImage()
     }
 }


### PR DESCRIPTION
# Description

- Currently, the kirakira effects have a high chance of displaying near the eyes and teeth, which are mostly lighter than its nearby area, and it causes the result to look scary for those cases.
- Therefore, this PR adds face masks to the kirakira effect to prevent the center of sparkles located on people's faces.

# Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/cardinalblue/pic-collage-ios/assets/40178645/29eb7ee3-38ad-4c52-bcbc-9f0c3978c28b

</td>
<td>

https://github.com/cardinalblue/pic-collage-ios/assets/40178645/ed0c7ccf-2382-4622-ad80-1ee440b8bda0

</td>
</tr>
</table>
