### PR TITLE
refactor: remove fatal error from the constructor of texture.

### DIFF
--- a/framework/Source/BasicOperation.swift
+++ b/framework/Source/BasicOperation.swift
@@ -85,7 +85,12 @@ open class BasicOperation: ImageProcessingOperation {
                     height: outputHeight,
                     timingStyle: firstInputTexture.timingStyle
                 )
-            else { return }
+            else {
+                assertionFailure("CommandBuffer or Texture creation failed")
+                removeTransientInputs()
+                updateTargetsWithTexture(firstInputTexture)
+                return
+            }
 
             guard (!activatePassthroughOnNextFrame) else { // Use this to allow a bootstrap of cyclical processing, like with a low pass filter
                 activatePassthroughOnNextFrame = false
@@ -110,7 +115,13 @@ open class BasicOperation: ImageProcessingOperation {
                             width: outputWidth,
                             height: outputHeight
                         )
-                    else { return }
+                    else {
+                        assertionFailure("CommandBuffer or Texture creation failed")
+                        removeTransientInputs()
+                        textureInputSemaphore.signal()
+                        updateTargetsWithTexture(firstInputTexture)
+                        return
+                    }
                     rotationCommandBuffer.renderQuad(pipelineState: sharedMetalRenderingDevice.passthroughRenderState, uniformSettings: uniformSettings, inputTextures: inputTextures, useNormalizedTextureCoordinates: useNormalizedTextureCoordinates, outputTexture: rotationOutputTexture)
                     rotationCommandBuffer.commit()
                     rotatedInputTextures = inputTextures

--- a/framework/Source/BasicOperation.swift
+++ b/framework/Source/BasicOperation.swift
@@ -52,10 +52,6 @@ open class BasicOperation: ImageProcessingOperation {
     
     public func newTextureAvailable(_ texture: Texture, fromSourceIndex: UInt) {
         let _ = textureInputSemaphore.wait(timeout:DispatchTime.distantFuture)
-        defer {
-            textureInputSemaphore.signal()
-        }
-        
         inputTextures[fromSourceIndex] = texture
         
         if (UInt(inputTextures.count) >= maximumInputs) || activatePassthroughOnNextFrame {
@@ -88,6 +84,7 @@ open class BasicOperation: ImageProcessingOperation {
             else {
                 assertionFailure("CommandBuffer or Texture creation failed")
                 removeTransientInputs()
+                textureInputSemaphore.signal()
                 updateTargetsWithTexture(firstInputTexture)
                 return
             }

--- a/framework/Source/Camera.swift
+++ b/framework/Source/Camera.swift
@@ -217,8 +217,8 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
                         outputWidth = bufferWidth
                         outputHeight = bufferHeight
                     }
-                    let outputTexture = Texture(device:sharedMetalRenderingDevice.device, orientation:.portrait, width:outputWidth, height:outputHeight, timingStyle: .videoFrame(timestamp: Timestamp(currentTime)))
-                    
+                    let outputTexture = Texture(device:sharedMetalRenderingDevice.device, orientation:.portrait, width:outputWidth, height:outputHeight, timingStyle: .videoFrame(timestamp: Timestamp(currentTime)))!
+
                     convertYUVToRGB(pipelineState:self.yuvConversionRenderPipelineState!, lookupTable:self.yuvLookupTable,
                                     luminanceTexture:Texture(orientation: self.orientation ?? self.location.imageOrientation(), texture:luminanceTexture),
                                     chrominanceTexture:Texture(orientation: self.orientation ?? self.location.imageOrientation(), texture:chrominanceTexture),

--- a/framework/Source/ImageGenerator.swift
+++ b/framework/Source/ImageGenerator.swift
@@ -6,7 +6,7 @@ public class ImageGenerator: ImageSource {
 
     public init(size:Size) {
         self.size = size
-        internalTexture = Texture(device:sharedMetalRenderingDevice.device, orientation:.portrait, width:Int(size.width), height:Int(size.height), timingStyle:.stillImage)
+        internalTexture = Texture(device:sharedMetalRenderingDevice.device, orientation:.portrait, width:Int(size.width), height:Int(size.height), timingStyle:.stillImage)!
     }
     
     public func transmitPreviousImage(to target:ImageConsumer, atIndex:UInt) {

--- a/framework/Source/MovieInput.swift
+++ b/framework/Source/MovieInput.swift
@@ -175,7 +175,7 @@ public class MovieInput: ImageSource {
         
         if let concreteLuminanceTextureRef = luminanceTextureRef, let concreteChrominanceTextureRef = chrominanceTextureRef,
             let luminanceTexture = CVMetalTextureGetTexture(concreteLuminanceTextureRef), let chrominanceTexture = CVMetalTextureGetTexture(concreteChrominanceTextureRef) {
-            let outputTexture = Texture(device:sharedMetalRenderingDevice.device, orientation:.portrait, width:bufferWidth, height:bufferHeight, timingStyle:.videoFrame(timestamp:Timestamp(withSampleTime)))
+            let outputTexture = Texture(device:sharedMetalRenderingDevice.device, orientation:.portrait, width:bufferWidth, height:bufferHeight, timingStyle:.videoFrame(timestamp:Timestamp(withSampleTime)))!
             
             convertYUVToRGB(pipelineState:self.yuvConversionRenderPipelineState, lookupTable:self.yuvLookupTable,
                             luminanceTexture:Texture(orientation:.portrait, texture:luminanceTexture),

--- a/framework/Source/MovieOutput.swift
+++ b/framework/Source/MovieOutput.swift
@@ -151,7 +151,7 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
         if (Int(round(self.size.width)) != texture.texture.width) && (Int(round(self.size.height)) != texture.texture.height) {
             let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer()
             
-            outputTexture = Texture(device:sharedMetalRenderingDevice.device, orientation: .portrait, width: Int(round(self.size.width)), height: Int(round(self.size.height)), timingStyle: texture.timingStyle)
+            outputTexture = Texture(device:sharedMetalRenderingDevice.device, orientation: .portrait, width: Int(round(self.size.width)), height: Int(round(self.size.height)), timingStyle: texture.timingStyle)!
 
             commandBuffer?.renderQuad(pipelineState: renderPipelineState, inputTextures: [0:texture], outputTexture: outputTexture)
             commandBuffer?.commit()

--- a/framework/Source/Operations/CBRescaleEffect.swift
+++ b/framework/Source/Operations/CBRescaleEffect.swift
@@ -31,14 +31,14 @@ public class CBRescaleEffect: BasicOperation {
         }
         
         let outputSize = calculateTargetSize(from: texture)
-        let outputTexture = Texture(
+        guard let outputTexture = Texture(
             device: sharedMetalRenderingDevice.device,
             orientation: texture.orientation,
             pixelFormat: texture.texture.pixelFormat,
             width: Int(outputSize.width),
             height: Int(outputSize.height),
             timingStyle: texture.timingStyle
-        )
+        ) else { return }
 
         inputTextures[0] = texture
         internalRenderFunction(commandBuffer: commandBuffer, outputTexture: outputTexture)

--- a/framework/Source/Operations/CBRescaleEffect.swift
+++ b/framework/Source/Operations/CBRescaleEffect.swift
@@ -38,7 +38,12 @@ public class CBRescaleEffect: BasicOperation {
             width: Int(outputSize.width),
             height: Int(outputSize.height),
             timingStyle: texture.timingStyle
-        ) else { return }
+        ) else {
+            assertionFailure("CommandBuffer or Texture creation failed")
+            removeTransientInputs()
+            updateTargetsWithTexture(texture)
+            return
+        }
 
         inputTextures[0] = texture
         internalRenderFunction(commandBuffer: commandBuffer, outputTexture: outputTexture)

--- a/framework/Source/Operations/HistogramEqualization.swift
+++ b/framework/Source/Operations/HistogramEqualization.swift
@@ -35,14 +35,14 @@ public class HistogramEqualization: ImageProcessingOperation {
             width: CGFloat(frameTexture.width),
             height: CGFloat(frameTexture.height)
         )
-        let outputTexture = Texture(
+        guard let outputTexture = Texture(
             device: sharedMetalRenderingDevice.device,
             orientation: texture.orientation,
             pixelFormat: texture.texture.pixelFormat,
             width: Int(size.width),
             height: Int(size.height),
             timingStyle: texture.timingStyle
-        )
+        ) else { return }
 
         inputTexture = texture
         renderer.render(

--- a/framework/Source/Operations/HistogramEqualization.swift
+++ b/framework/Source/Operations/HistogramEqualization.swift
@@ -42,7 +42,12 @@ public class HistogramEqualization: ImageProcessingOperation {
             width: Int(size.width),
             height: Int(size.height),
             timingStyle: texture.timingStyle
-        ) else { return }
+        ) else {
+            assertionFailure("CommandBuffer or Texture creation failed")
+            removeTransientInputs()
+            updateTargetsWithTexture(texture)
+            return
+        }
 
         inputTexture = texture
         renderer.render(
@@ -51,6 +56,7 @@ public class HistogramEqualization: ImageProcessingOperation {
         )
         inputTexture = nil
 
+        removeTransientInputs()
         updateTargetsWithTexture(outputTexture)
     }
 }

--- a/framework/Source/PictureOutput.swift
+++ b/framework/Source/PictureOutput.swift
@@ -50,9 +50,9 @@ public class PictureOutput: ImageConsumer {
             storedTexture = texture
         }
         
-        if let imageCallback = imageAvailableCallback {
-            let cgImageFromBytes = texture.cgImage()
-            
+        if let imageCallback = imageAvailableCallback,
+           let cgImageFromBytes = texture.cgImage() {
+
             // TODO: Let people specify orientations
 #if canImport(UIKit)
             let image = UIImage(cgImage:cgImageFromBytes, scale:1.0, orientation:.up)
@@ -61,15 +61,15 @@ public class PictureOutput: ImageConsumer {
 #endif
 
             imageCallback(image)
-            
+
             if onlyCaptureNextFrame {
                 imageAvailableCallback = nil
             }
         }
-        
-        if let imageCallback = encodedImageAvailableCallback {
-            let cgImageFromBytes = texture.cgImage()
-            
+
+        if let imageCallback = encodedImageAvailableCallback,
+           let cgImageFromBytes = texture.cgImage() {
+
             let imageData:Data
 #if canImport(UIKit)
             let image = UIImage(cgImage:cgImageFromBytes, scale:1.0, orientation:.up)


### PR DESCRIPTION
# Descriptions:

- To fix the following crash caused by a fetal error from GPUImage3
   <img src=https://github.com/cardinalblue/GPUImage3/assets/40178645/96fbd7ea-25c1-4794-a732-b4d1cb55adf6 width=300 />
- The exception occurs when the makeTexture function of the MTLDevice returns nil; it is associated with some memory issue, which we have fixed. However, it's still safer not to use fetal error in this case.

# Solution:
- Following the solution from CBVisualEffectBuiltIn, we skip the process when this case occurs
- Force unwrap the value, similar to the original behavior using fetalError, for those that won't be used in PicCollage

# Topics for discussion:
In CBVisualEffectBuiltIn, we use the input as the output directly when the makeTexture function return nil:
  1. Should we follow this behavior, then pass the inputTexture to the next filter by the newTextureAvailable?
      - The user may be confused due to there will be a result, but without any changes.
  3. Or just skip the process by stopping the invoking chain (current implementation in this PR)
      - It's more obvious to let the user know that there's a bug here, because there will be no image of the result.