### PR TITLE
Add dummy file for resource bundle accessor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             name: "GPUImage",
             path: "framework/Source",
             exclude: ["Linux", "Operations/Shaders"],
-            resources: [ ]
+            resources: [.process("Resources")]
         ),
     ],
     swiftLanguageVersions: [.v4_2]

--- a/framework/Source/Resources/dummy.txt
+++ b/framework/Source/Resources/dummy.txt
@@ -1,0 +1,1 @@
+Dummy file to allow resource bundle accessor


### PR DESCRIPTION
`GPUImage3` doesn't contain a Resources directory so resource bundle accessor can't be auto generated for PicCollage with Tuist, causing compile error [HERE](https://github.com/cardinalblue/GPUImage3/blob/master/framework/Source/MetalRenderingDevice.swift#L42).

This PR adds a dummy resource to enable resource bundle accessor.

Ref: https://stackoverflow.com/a/63242343/4844397

